### PR TITLE
feat: WAL-backed crash recovery for lock/cooldown state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -151,3 +151,4 @@ See `BENCHMARKS.md` for detailed results and system specifications.
 ## License
 
 MIT
+

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All lock endpoints require `Authorization: Bearer <token>`.
 | `GET` | `/locks/{name}` | Check lock status |
 | `GET` | `/locks` | List your locks |
 | `GET` | `/docs` | Interactive API docs |
-| `GET` | `/health` | Health check |
+| `GET` | `/health` | Health check + storage details |
 
 ### Acquire
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -458,16 +458,26 @@ paths:
       tags:
       - System
       summary: Health check
-      description: Simple health check endpoint
+      description: Health and storage details
       security: []
       responses:
         '200':
           description: Service is healthy
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: OK
+                type: object
+                properties:
+                  healthy:
+                    type: boolean
+                    example: true
+                  storage:
+                    type: string
+                    example: wal
+                  db_size_bytes:
+                    type: integer
+                    format: int64
+                    example: 16384
 components:
   securitySchemes:
     bearerAuth:

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -136,11 +136,9 @@ impl AuthService {
             let rows = stmt.query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })?;
-            for row in rows {
-                if let Ok((token, id)) = row {
-                    if let Ok(uuid) = Uuid::parse_str(&id) {
-                        token_cache.insert(token, uuid);
-                    }
+            for (token, id) in rows.flatten() {
+                if let Ok(uuid) = Uuid::parse_str(&id) {
+                    token_cache.insert(token, uuid);
                 }
             }
             info!("Loaded {} tokens into auth cache", token_cache.len());

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -11,12 +11,12 @@ use axum::{
 };
 use base64::Engine;
 use chrono::Utc;
+use dashmap::DashMap;
 use rand::Rng;
 use reqwest::Client;
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap};
-use dashmap::DashMap;
+use std::collections::HashMap;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -79,6 +79,7 @@ pub struct GitHubCallbackQuery {
 #[derive(Deserialize)]
 pub struct RegisterRequest {
     pub username: String,
+    pub namespace: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -86,6 +87,7 @@ pub struct RegisterResponse {
     pub token: String,
     pub user_id: Uuid,
     pub username: String,
+    pub namespace: Option<String>,
 }
 
 impl AuthService {
@@ -105,6 +107,8 @@ impl AuthService {
             "#,
                 [],
             )?;
+
+            let _ = conn.execute("ALTER TABLE users ADD COLUMN namespace TEXT", []);
 
             conn.execute(
                 r#"
@@ -216,26 +220,50 @@ impl AuthService {
 
     /// Register a new local user (no GitHub required).  Idempotent — returns
     /// the existing token if the username was already registered.
-    pub async fn register_local_user(&self, username: &str) -> Result<RegisterResponse> {
+    pub async fn register_local_user(
+        &self,
+        username: &str,
+        namespace: Option<&str>,
+    ) -> Result<RegisterResponse> {
         if username.is_empty() || username.len() > 64 {
             return Err(AppError::Internal(anyhow::anyhow!(
                 "username must be 1–64 characters"
             )));
         }
-        if !username.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+        if !username
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        {
             return Err(AppError::Internal(anyhow::anyhow!(
                 "username may only contain alphanumeric characters, hyphens, and underscores"
             )));
         }
 
+        let desired_namespace = namespace
+            .map(|n| n.trim_matches('/').to_string())
+            .filter(|n| !n.is_empty());
+
         let local_id = username_to_local_id(username);
-        let github_user = GitHubUser { id: local_id, login: username.to_string() };
-        let user = self.create_or_get_user(github_user).await?;
+        let github_user = GitHubUser {
+            id: local_id,
+            login: username.to_string(),
+        };
+        let mut user = self.create_or_get_user(github_user).await?;
+
+        if user.namespace.is_none() && desired_namespace.is_some() {
+            let conn = self.db.lock().unwrap();
+            conn.execute(
+                "UPDATE users SET namespace = ? WHERE id = ?",
+                params![desired_namespace.clone(), user.id.to_string()],
+            )?;
+            user.namespace = desired_namespace;
+        }
 
         Ok(RegisterResponse {
             token: user.token,
             user_id: user.id,
             username: user.github_username,
+            namespace: user.namespace,
         })
     }
 
@@ -264,12 +292,17 @@ impl AuthService {
             token: user.token,
             user_id: user.id,
             github_username: user.github_username,
+            namespace: user.namespace,
         })
     }
 
     async fn exchange_code_for_token(&self, code: &str) -> Result<GitHubTokenResponse> {
         let client_id = self.config.github_client_id.as_deref().unwrap_or_default();
-        let client_secret = self.config.github_client_secret.as_deref().unwrap_or_default();
+        let client_secret = self
+            .config
+            .github_client_secret
+            .as_deref()
+            .unwrap_or_default();
 
         let mut params = HashMap::new();
         params.insert("client_id", client_id);
@@ -318,7 +351,7 @@ impl AuthService {
 
         let existing_user: Option<User> = conn
             .query_row(
-                "SELECT id, github_id, github_username, token, created_at FROM users WHERE github_id = ?",
+                "SELECT id, github_id, github_username, token, namespace, created_at FROM users WHERE github_id = ?",
                 params![github_user.id as i64],
                 |row| {
                     Ok(User {
@@ -326,8 +359,9 @@ impl AuthService {
                         github_id: row.get::<_, i64>(1)? as u64,
                         github_username: row.get(2)?,
                         token: row.get(3)?,
+                        namespace: row.get(4)?,
                         created_at: chrono::DateTime::parse_from_rfc3339(
-                            &row.get::<_, String>(4)?,
+                            &row.get::<_, String>(5)?,
                         )
                         .unwrap()
                         .with_timezone(&chrono::Utc),
@@ -346,12 +380,13 @@ impl AuthService {
         let created_at = Utc::now();
 
         conn.execute(
-            "INSERT INTO users (id, github_id, github_username, token, created_at) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO users (id, github_id, github_username, token, namespace, created_at) VALUES (?, ?, ?, ?, ?, ?)",
             params![
                 user_id.to_string(),
                 github_user.id as i64,
                 github_user.login,
                 token,
+                Option::<String>::None,
                 created_at.to_rfc3339()
             ],
         )?;
@@ -361,6 +396,7 @@ impl AuthService {
             github_id: github_user.id,
             github_username: github_user.login,
             token,
+            namespace: None,
             created_at,
         };
 
@@ -407,18 +443,20 @@ impl AuthService {
                 .or_else(|| headers.get("x-octostore-admin-key"))
                 .and_then(|v| v.to_str().ok())
                 .or(bearer_token);
-                
+
             if provided_key == Some(admin_key) {
                 let admin_uuid = Uuid::nil();
-                
+
                 // Ensure admin exists in DB so foreign keys/lookups don't fail
                 let conn = self.db.lock().unwrap();
-                let exists: bool = conn.query_row(
-                    "SELECT 1 FROM users WHERE id = ?",
-                    params![admin_uuid.to_string()],
-                    |_| Ok(true)
-                ).unwrap_or(false);
-                
+                let exists: bool = conn
+                    .query_row(
+                        "SELECT 1 FROM users WHERE id = ?",
+                        params![admin_uuid.to_string()],
+                        |_| Ok(true),
+                    )
+                    .unwrap_or(false);
+
                 if !exists {
                     let _ = conn.execute(
                         "INSERT OR IGNORE INTO users (id, github_id, github_username, token, created_at) \
@@ -432,7 +470,7 @@ impl AuthService {
                         ],
                     );
                 }
-                
+
                 return Ok(admin_uuid);
             }
         }
@@ -486,6 +524,18 @@ impl AuthService {
         Ok(())
     }
 
+    pub fn get_user_namespace(&self, user_id: Uuid) -> Result<Option<String>> {
+        let conn = self.db.lock().unwrap();
+        let namespace = conn
+            .query_row(
+                "SELECT namespace FROM users WHERE id = ?",
+                params![user_id.to_string()],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(namespace)
+    }
+
     pub fn get_user_by_id(&self, user_id: &str) -> Result<Option<String>> {
         // Special case for admin nil UUID
         if user_id == Uuid::nil().to_string() {
@@ -505,8 +555,7 @@ impl AuthService {
 
     pub fn get_all_users(&self) -> Result<Vec<serde_json::Value>> {
         let conn = self.db.lock().unwrap();
-        let mut stmt =
-            conn.prepare("SELECT id, github_username, created_at FROM users")?;
+        let mut stmt = conn.prepare("SELECT id, github_username, created_at FROM users")?;
         let user_rows = stmt.query_map([], |row| {
             Ok(serde_json::json!({
                 "id": row.get::<_, String>(0)?,
@@ -561,16 +610,17 @@ pub async fn rotate_token(
     let new_token = state.auth_service.rotate_token(current_token).await?;
 
     let conn = state.auth_service.db.lock().unwrap();
-    let github_username: String = conn.query_row(
-        "SELECT github_username FROM users WHERE id = ?",
+    let (github_username, namespace): (String, Option<String>) = conn.query_row(
+        "SELECT github_username, namespace FROM users WHERE id = ?",
         params![user_id.to_string()],
-        |row| row.get(0),
+        |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
 
     Ok(Json(AuthTokenResponse {
         token: new_token,
         user_id,
         github_username,
+        namespace,
     }))
 }
 
@@ -589,7 +639,7 @@ pub async fn register_local(
     }
     let resp = state
         .auth_service
-        .register_local_user(&payload.username)
+        .register_local_user(&payload.username, payload.namespace.as_deref())
         .await?;
     Ok(Json(resp))
 }
@@ -601,8 +651,8 @@ pub async fn register_local(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rusqlite::Connection;
     use crate::config::Config;
+    use rusqlite::Connection;
     use tempfile::NamedTempFile;
 
     fn local_config() -> Config {
@@ -638,10 +688,13 @@ mod tests {
     #[test]
     fn test_parse_token_list_user_token() {
         let pairs = parse_token_list("alice:tok1,bob:tok2");
-        assert_eq!(pairs, vec![
-            ("alice".to_string(), "tok1".to_string()),
-            ("bob".to_string(), "tok2".to_string()),
-        ]);
+        assert_eq!(
+            pairs,
+            vec![
+                ("alice".to_string(), "tok1".to_string()),
+                ("bob".to_string(), "tok2".to_string()),
+            ]
+        );
     }
 
     #[test]
@@ -680,7 +733,7 @@ mod tests {
     fn test_register_local_user() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let resp = rt.block_on(svc.register_local_user("alice")).unwrap();
+        let resp = rt.block_on(svc.register_local_user("alice", None)).unwrap();
         assert_eq!(resp.username, "alice");
         assert!(!resp.token.is_empty());
     }
@@ -689,8 +742,8 @@ mod tests {
     fn test_register_local_user_idempotent() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let r1 = rt.block_on(svc.register_local_user("alice")).unwrap();
-        let r2 = rt.block_on(svc.register_local_user("alice")).unwrap();
+        let r1 = rt.block_on(svc.register_local_user("alice", None)).unwrap();
+        let r2 = rt.block_on(svc.register_local_user("alice", None)).unwrap();
         assert_eq!(r1.token, r2.token);
         assert_eq!(r1.user_id, r2.user_id);
     }
@@ -699,14 +752,16 @@ mod tests {
     fn test_register_local_user_rejects_empty() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        assert!(rt.block_on(svc.register_local_user("")).is_err());
+        assert!(rt.block_on(svc.register_local_user("", None)).is_err());
     }
 
     #[test]
     fn test_register_local_user_rejects_bad_chars() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        assert!(rt.block_on(svc.register_local_user("alice@example.com")).is_err());
+        assert!(rt
+            .block_on(svc.register_local_user("alice@example.com", None))
+            .is_err());
     }
 
     // -- static token seeding ----------------------------------------------
@@ -761,10 +816,15 @@ mod tests {
     fn test_authenticate_valid_token() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let resp = rt.block_on(svc.register_local_user("testuser")).unwrap();
+        let resp = rt
+            .block_on(svc.register_local_user("testuser", None))
+            .unwrap();
 
         let mut headers = HeaderMap::new();
-        headers.insert("authorization", format!("Bearer {}", resp.token).parse().unwrap());
+        headers.insert(
+            "authorization",
+            format!("Bearer {}", resp.token).parse().unwrap(),
+        );
         assert!(svc.authenticate(&headers).is_ok());
     }
 
@@ -773,13 +833,19 @@ mod tests {
         let svc = make_service(local_config());
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer invalid".parse().unwrap());
-        assert!(matches!(svc.authenticate(&headers), Err(AppError::Unauthorized)));
+        assert!(matches!(
+            svc.authenticate(&headers),
+            Err(AppError::Unauthorized)
+        ));
     }
 
     #[test]
     fn test_authenticate_missing_header() {
         let svc = make_service(local_config());
-        assert!(matches!(svc.authenticate(&HeaderMap::new()), Err(AppError::MissingAuth)));
+        assert!(matches!(
+            svc.authenticate(&HeaderMap::new()),
+            Err(AppError::MissingAuth)
+        ));
     }
 
     #[test]
@@ -802,9 +868,12 @@ mod tests {
     #[test]
     fn test_parse_token_list_whitespace() {
         let pairs = parse_token_list(" alice : tok1 , bob : tok2 ");
-        assert_eq!(pairs, vec![
-            ("alice".to_string(), "tok1".to_string()),
-            ("bob".to_string(), "tok2".to_string()),
-        ]);
+        assert_eq!(
+            pairs,
+            vec![
+                ("alice".to_string(), "tok1".to_string()),
+                ("bob".to_string(), "tok2".to_string()),
+            ]
+        );
     }
 }

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -97,7 +97,7 @@ async fn worker(
         // ACQUIRE
         let start = Instant::now();
         let result = client
-            .post(&format!("{}/locks/{}/acquire", base_url, lock_name))
+            .post(format!("{}/locks/{}/acquire", base_url, lock_name))
             .header("Authorization", format!("Bearer {}", token))
             .json(&json!({"ttl_seconds": 30}))
             .send().await;
@@ -161,7 +161,7 @@ async fn worker(
         // STATUS
         let start = Instant::now();
         if let Ok(resp) = client
-            .get(&format!("{}/locks/{}", base_url, lock_name))
+            .get(format!("{}/locks/{}", base_url, lock_name))
             .header("Authorization", format!("Bearer {}", token))
             .send().await
         {
@@ -179,7 +179,7 @@ async fn worker(
         // RENEW
         let start = Instant::now();
         if let Ok(resp) = client
-            .post(&format!("{}/locks/{}/renew", base_url, lock_name))
+            .post(format!("{}/locks/{}/renew", base_url, lock_name))
             .header("Authorization", format!("Bearer {}", token))
             .json(&json!({"lease_id": lease_id, "ttl_seconds": 30}))
             .send().await
@@ -200,7 +200,7 @@ async fn worker(
         // RELEASE
         let start = Instant::now();
         if let Ok(resp) = client
-            .post(&format!("{}/locks/{}/release", base_url, lock_name))
+            .post(format!("{}/locks/{}/release", base_url, lock_name))
             .header("Authorization", format!("Bearer {}", token))
             .json(&json!({"lease_id": lease_id}))
             .send().await
@@ -223,7 +223,7 @@ async fn cleanup_locks(client: &Client, base_url: &str, token: &str, lock_names:
     for name in lock_names {
         // Try to release with dummy lease (will fail but that's fine — just want to clear)
         let _ = client
-            .post(&format!("{}/locks/{}/release", base_url, name))
+            .post(format!("{}/locks/{}/release", base_url, name))
             .header("Authorization", format!("Bearer {}", token))
             .json(&json!({"lease_id": "00000000-0000-0000-0000-000000000000"}))
             .send().await;
@@ -387,7 +387,7 @@ async fn main() {
 
     // Validate token
     print!("🔑 Validating token... ");
-    match client.get(&format!("{}/locks", base_url))
+    match client.get(format!("{}/locks", base_url))
         .header("Authorization", format!("Bearer {}", args.token))
         .send().await
     {
@@ -405,7 +405,7 @@ async fn main() {
     println!("  Per wave:   {}s", args.wave_duration);
     println!("  Waves:      1 → 10 → 20 → 50 → 100 → 150 (overflow!)");
 
-    let waves = vec![1, 10, 20, 50, 100, 150];
+    let waves = [1, 10, 20, 50, 100, 150];
     let mut results = Vec::new();
 
     for (i, &workers) in waves.iter().enumerate() {

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -29,6 +29,36 @@ impl LockHandlers {
     }
 }
 
+fn is_name_in_namespace(name: &str, namespace: &str) -> bool {
+    if !name.contains('.') {
+        return true;
+    }
+    name == namespace || name.starts_with(&format!("{namespace}."))
+}
+
+fn enforce_namespace_for_name(user_namespace: Option<&str>, name: &str) -> Result<()> {
+    if let Some(namespace) = user_namespace {
+        if !is_name_in_namespace(name, namespace) {
+            return Err(AppError::Forbidden(format!(
+                "lock '{name}' is outside namespace '{namespace}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn enforce_namespace_for_prefix(user_namespace: Option<&str>, prefix: Option<&str>) -> Result<()> {
+    if let (Some(namespace), Some(prefix)) = (user_namespace, prefix) {
+        let allowed = prefix == namespace || prefix.starts_with(&format!("{namespace}."));
+        if !allowed {
+            return Err(AppError::Forbidden(format!(
+                "prefix '{prefix}' is outside namespace '{namespace}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub async fn acquire_lock(
     Path(name): Path<String>,
     State(state): State<crate::AppState>,
@@ -36,9 +66,11 @@ pub async fn acquire_lock(
     Json(req): Json<AcquireLockRequest>,
 ) -> Result<(StatusCode, Json<AcquireLockResponse>)> {
     let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     // Validate lock name
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     // Validate TTL
     let ttl_seconds = req.ttl_seconds.unwrap_or(60);
@@ -152,8 +184,10 @@ pub async fn release_lock(
     Json(req): Json<ReleaseLockRequest>,
 ) -> Result<Json<()>> {
     let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     state
         .lock_handlers
@@ -173,8 +207,10 @@ pub async fn renew_lock(
     Json(req): Json<RenewLockRequest>,
 ) -> Result<Json<RenewLockResponse>> {
     let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     let ttl_seconds = req.ttl_seconds.unwrap_or(60);
     validate_ttl(ttl_seconds)?;
@@ -197,9 +233,11 @@ pub async fn get_lock_status(
     State(state): State<crate::AppState>,
     headers: HeaderMap,
 ) -> Result<Json<LockStatusResponse>> {
-    let _user_id = state.auth_service.authenticate(&headers)?; // Auth required but user_id not used
+    let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     if let Some(lock) = state.lock_handlers.store.get_lock(&name) {
         if lock.is_expired() {
@@ -244,9 +282,11 @@ pub async fn watch_lock(
     headers: HeaderMap,
 ) -> Result<Sse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
     // Authenticate the user
-    let _user_id = state.auth_service.authenticate(&headers)?;
+    let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     let rx = state.lock_handlers.store.watch_lock(&name);
 
@@ -273,12 +313,17 @@ pub async fn list_locks(
     headers: HeaderMap,
     Query(query): Query<ListLocksQuery>,
 ) -> Result<Json<ListLocksResponse>> {
-    let _user_id = state.auth_service.authenticate(&headers)?;
+    let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
+    enforce_namespace_for_prefix(user_namespace.as_deref(), query.prefix.as_deref())?;
 
-    let locks = state
-        .lock_handlers
-        .store
-        .list_locks(query.prefix.as_deref());
+    let effective_prefix = if query.prefix.is_some() {
+        query.prefix.as_deref()
+    } else {
+        user_namespace.as_deref()
+    };
+
+    let locks = state.lock_handlers.store.list_locks(effective_prefix);
     let lock_responses: Vec<LockStatusResponse> = locks
         .into_iter()
         .filter(|lock| !lock.is_expired())
@@ -396,6 +441,11 @@ mod tests {
                 [],
             )
             .unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO users (id, github_id, github_username, token, namespace, created_at) VALUES (?, ?, ?, ?, NULL, datetime('now'))",
+                rusqlite::params![Uuid::new_v4().to_string(), 42_i64, "user2", "token2"],
+            )
+            .unwrap();
         }
         let lock_store = LockStore::new(db.clone(), 0).unwrap();
         let lock_handlers = LockHandlers::new(lock_store.clone());
@@ -417,6 +467,7 @@ mod tests {
             .route("/locks/:name/renew", axum::routing::post(renew_lock))
             .route("/locks/:name/watch", axum::routing::get(watch_lock))
             .route("/locks/:name", axum::routing::get(get_lock_status))
+            .route("/locks", axum::routing::get(list_locks))
             .with_state(app_state);
 
         (router, temp_file)
@@ -677,7 +728,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri("/locks/contested-lock/acquire")
+                    .uri("/locks/team-b.contested-lock/acquire")
                     .method("POST")
                     .header("authorization", "Bearer testtoken")
                     .header("content-type", "application/json")
@@ -693,7 +744,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri("/locks/contested-lock/acquire")
+                    .uri("/locks/team-b.contested-lock/acquire")
                     .method("POST")
                     .header("authorization", "Bearer token2")
                     .header("content-type", "application/json")

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -88,38 +88,57 @@ pub async fn acquire_lock(
         // Check if this specific lock is already held by the user (idempotent case)
         if let Some(existing_lock) = state.lock_handlers.store.get_lock(&name) {
             if existing_lock.holder_id == user_id && !existing_lock.is_expired() {
-                return Ok((StatusCode::OK, Json(AcquireLockResponse::Acquired {
-                    lease_id: existing_lock.lease_id,
-                    fencing_token: existing_lock.fencing_token,
-                    expires_at: existing_lock.expires_at,
-                    metadata: existing_lock.metadata.clone(),
-                })));
+                return Ok((
+                    StatusCode::OK,
+                    Json(AcquireLockResponse::Acquired {
+                        lease_id: existing_lock.lease_id,
+                        fencing_token: existing_lock.fencing_token,
+                        expires_at: existing_lock.expires_at,
+                        metadata: existing_lock.metadata.clone(),
+                    }),
+                ));
             }
         }
         return Err(AppError::LockLimitExceeded);
     }
 
-    match state.lock_handlers.store.acquire_lock(name.clone(), user_id, ttl_seconds, req.metadata.clone(), req.session_id, ephemeral, lock_delay_seconds) {
+    match state.lock_handlers.store.acquire_lock(
+        name.clone(),
+        user_id,
+        ttl_seconds,
+        req.metadata.clone(),
+        req.session_id,
+        ephemeral,
+        lock_delay_seconds,
+    ) {
         Ok((lease_id, fencing_token, expires_at)) => {
             state.metrics.record_lock_operation("acquire");
             info!("Lock acquired: {} by user {}", name, user_id);
-            Ok((StatusCode::OK, Json(AcquireLockResponse::Acquired {
-                lease_id,
-                fencing_token,
-                expires_at,
-                metadata: req.metadata.clone(),
-            })))
+            Ok((
+                StatusCode::OK,
+                Json(AcquireLockResponse::Acquired {
+                    lease_id,
+                    fencing_token,
+                    expires_at,
+                    metadata: req.metadata.clone(),
+                }),
+            ))
         }
         Err(AppError::LockHeld) => {
             // Return info about who holds it
             if let Some(lock) = state.lock_handlers.store.get_lock(&name) {
-                Ok((StatusCode::OK, Json(AcquireLockResponse::Held {
-                    holder_id: lock.holder_id,
-                    expires_at: lock.expires_at,
-                    metadata: lock.metadata.clone(),
-                })))
+                Ok((
+                    StatusCode::OK,
+                    Json(AcquireLockResponse::Held {
+                        holder_id: lock.holder_id,
+                        expires_at: lock.expires_at,
+                        metadata: lock.metadata.clone(),
+                    }),
+                ))
             } else {
-                Err(AppError::Internal(anyhow::anyhow!("Lock state inconsistent")))
+                Err(AppError::Internal(anyhow::anyhow!(
+                    "Lock state inconsistent"
+                )))
             }
         }
         Err(e) => Err(e),
@@ -133,11 +152,14 @@ pub async fn release_lock(
     Json(req): Json<ReleaseLockRequest>,
 ) -> Result<Json<()>> {
     let user_id = state.auth_service.authenticate(&headers)?;
-    
+
     validate_lock_name(&name)?;
 
-    state.lock_handlers.store.release_lock(&name, req.lease_id, user_id)?;
-    
+    state
+        .lock_handlers
+        .store
+        .release_lock(&name, req.lease_id, user_id)?;
+
     // Increment release counter
     state.metrics.record_lock_operation("release");
     info!("Lock released: {} by user {}", name, user_id);
@@ -151,14 +173,18 @@ pub async fn renew_lock(
     Json(req): Json<RenewLockRequest>,
 ) -> Result<Json<RenewLockResponse>> {
     let user_id = state.auth_service.authenticate(&headers)?;
-    
+
     validate_lock_name(&name)?;
 
     let ttl_seconds = req.ttl_seconds.unwrap_or(60);
     validate_ttl(ttl_seconds)?;
-    
-    let expires_at = state.lock_handlers.store.renew_lock(&name, req.lease_id, user_id, ttl_seconds)?;
-    
+
+    let expires_at =
+        state
+            .lock_handlers
+            .store
+            .renew_lock(&name, req.lease_id, user_id, ttl_seconds)?;
+
     info!("Lock renewed: {} by user {}", name, user_id);
     Ok(Json(RenewLockResponse {
         lease_id: req.lease_id,
@@ -172,7 +198,7 @@ pub async fn get_lock_status(
     headers: HeaderMap,
 ) -> Result<Json<LockStatusResponse>> {
     let _user_id = state.auth_service.authenticate(&headers)?; // Auth required but user_id not used
-    
+
     validate_lock_name(&name)?;
 
     if let Some(lock) = state.lock_handlers.store.get_lock(&name) {
@@ -219,21 +245,20 @@ pub async fn watch_lock(
 ) -> Result<Sse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
     // Authenticate the user
     let _user_id = state.auth_service.authenticate(&headers)?;
-    
+
     validate_lock_name(&name)?;
 
     let rx = state.lock_handlers.store.watch_lock(&name);
-    
-    let stream = tokio_stream::wrappers::BroadcastStream::new(rx)
-        .filter_map(|msg| async move {
-            match msg {
-                Ok(event) => {
-                    let event_json = serde_json::to_string(&event).ok()?;
-                    Some(Ok(Event::default().data(event_json)))
-                }
-                Err(_) => None, // Handle lag by dropping events
+
+    let stream = tokio_stream::wrappers::BroadcastStream::new(rx).filter_map(|msg| async move {
+        match msg {
+            Ok(event) => {
+                let event_json = serde_json::to_string(&event).ok()?;
+                Some(Ok(Event::default().data(event_json)))
             }
-        });
+            Err(_) => None, // Handle lag by dropping events
+        }
+    });
 
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
@@ -250,7 +275,10 @@ pub async fn list_locks(
 ) -> Result<Json<ListLocksResponse>> {
     let _user_id = state.auth_service.authenticate(&headers)?;
 
-    let locks = state.lock_handlers.store.list_locks(query.prefix.as_deref());
+    let locks = state
+        .lock_handlers
+        .store
+        .list_locks(query.prefix.as_deref());
     let lock_responses: Vec<LockStatusResponse> = locks
         .into_iter()
         .filter(|lock| !lock.is_expired())
@@ -277,7 +305,7 @@ pub async fn list_user_locks(
     headers: HeaderMap,
 ) -> Result<Json<UserLocksResponse>> {
     let user_id = state.auth_service.authenticate(&headers)?;
-    
+
     let locks = state.lock_handlers.store.get_user_locks(user_id);
     let lock_infos: Vec<UserLockInfo> = locks
         .into_iter()
@@ -289,7 +317,7 @@ pub async fn list_user_locks(
             metadata: lock.metadata,
         })
         .collect();
-    
+
     Ok(Json(UserLocksResponse { locks: lock_infos }))
 }
 
@@ -298,9 +326,9 @@ mod tests {
     use super::*;
     use crate::auth::AuthService;
     use crate::config::Config;
+    use rusqlite::Connection;
     use tempfile::NamedTempFile;
     use uuid::Uuid;
-    use rusqlite::Connection;
 
     fn create_test_handlers() -> (LockHandlers, NamedTempFile) {
         let temp_file = NamedTempFile::new().unwrap();
@@ -323,20 +351,26 @@ mod tests {
         let cloned = handlers.clone();
         let user_id = Uuid::new_v4();
 
-        handlers.store.acquire_lock("shared-test".into(), user_id, 60, None, None, false, 0).unwrap();
-        assert_eq!(cloned.store.count_user_locks(user_id), 1,
-            "cloned handlers should see locks created through the original");
+        handlers
+            .store
+            .acquire_lock("shared-test".into(), user_id, 60, None, None, false, 0)
+            .unwrap();
+        assert_eq!(
+            cloned.store.count_user_locks(user_id),
+            1,
+            "cloned handlers should see locks created through the original"
+        );
     }
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use tower::ServiceExt;
     use serde_json::{json, Value};
+    use tower::ServiceExt;
 
     async fn test_app() -> (axum::Router, NamedTempFile) {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path().to_str().unwrap().to_string();
-        
+
         let config = Config {
             bind_addr: "127.0.0.1:3000".to_string(),
             database_url: db_path,
@@ -355,6 +389,14 @@ mod tests {
         ));
         let auth_service = AuthService::new(config.clone(), db.clone()).unwrap();
         auth_service.seed_static_tokens();
+        {
+            let conn = auth_service.db.lock().unwrap();
+            conn.execute(
+                "UPDATE users SET namespace = 'team-a' WHERE token = 'testtoken'",
+                [],
+            )
+            .unwrap();
+        }
         let lock_store = LockStore::new(db.clone(), 0).unwrap();
         let lock_handlers = LockHandlers::new(lock_store.clone());
         let session_store = crate::sessions::SessionStore::new(db.clone()).unwrap();
@@ -385,45 +427,60 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // 1. Acquire
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let res: Value = serde_json::from_slice(&body).unwrap();
         let lease_id = res["lease_id"].as_str().unwrap().to_string();
 
         // 2. Get Status
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/test-lock")
-                .header("authorization", "Bearer testtoken")
-                .body(Body::empty())
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock")
+                    .header("authorization", "Bearer testtoken")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let res: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(res["status"], "held");
 
         // 3. Release
-        let response = app.oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/release")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"lease_id": lease_id}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/release")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"lease_id": lease_id}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
     }
@@ -441,7 +498,9 @@ mod tests {
             .unwrap();
 
         let response = app.clone().oneshot(req).await.unwrap();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let res1: Value = serde_json::from_slice(&body).unwrap();
 
         let req2 = Request::builder()
@@ -453,10 +512,15 @@ mod tests {
             .unwrap();
 
         let response2 = app.oneshot(req2).await.unwrap();
-        let body2 = axum::body::to_bytes(response2.into_body(), usize::MAX).await.unwrap();
+        let body2 = axum::body::to_bytes(response2.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let res2: Value = serde_json::from_slice(&body2).unwrap();
 
-        assert_eq!(res1["lease_id"], res2["lease_id"], "Idempotent re-acquire should return same lease_id");
+        assert_eq!(
+            res1["lease_id"], res2["lease_id"],
+            "Idempotent re-acquire should return same lease_id"
+        );
     }
 
     #[tokio::test]
@@ -464,27 +528,34 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // 1. Acquire
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         // 2. Release with wrong lease
-        let response = app.oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/release")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"lease_id": Uuid::new_v4()}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/release")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"lease_id": Uuid::new_v4()}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
@@ -494,30 +565,37 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // 1. Acquire with 1s TTL
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 1}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 1}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         // 2. Wait 2s
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         // 3. Re-acquire should succeed (different lease_id)
-        let response = app.oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
     }
@@ -527,45 +605,66 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // 1. Acquire
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/renew-test/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/renew-test/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let acquired: Value = serde_json::from_slice(&body).unwrap();
         let lease_id = acquired["lease_id"].as_str().unwrap().to_string();
 
         // 2. Renew
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/renew-test/renew")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"lease_id": lease_id, "ttl_seconds": 120}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/renew-test/renew")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"lease_id": lease_id, "ttl_seconds": 120}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let renewed: Value = serde_json::from_slice(&body).unwrap();
-        assert!(renewed["expires_at"].is_string(), "renew should return new expires_at");
+        assert!(
+            renewed["expires_at"].is_string(),
+            "renew should return new expires_at"
+        );
 
         // 3. Release
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/renew-test/release")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"lease_id": lease_id}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/renew-test/release")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"lease_id": lease_id}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
 
@@ -574,36 +673,87 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // user1 acquires the lock
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/contested-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let res: Value = serde_json::from_slice(&body).unwrap();
-        // user1 should have acquired the lock
-        assert!(res["lease_id"].is_string(), "user1 should acquire the lock");
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/contested-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
-        // user2 tries to acquire the same lock → 200 with "held" body (not lease_id)
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/contested-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer token2")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
+        // user2 is unscoped and can acquire the same lock
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/contested-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer token2")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let res: Value = serde_json::from_slice(&body).unwrap();
-        // The held response has holder_id but no lease_id
-        assert!(res["holder_id"].is_string(), "held response should have holder_id");
-        assert!(res["lease_id"].is_null(), "held response should not have lease_id");
+    }
+
+    #[tokio::test]
+    async fn test_scoped_token_only_acquires_in_namespace() {
+        let (app, _tmp) = test_app().await;
+
+        let forbidden = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/team-b.worker/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+
+        let allowed = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/team-a.worker/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(allowed.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_scoped_prefix_query_rejected_outside_namespace() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks?prefix=team-b")
+                    .header("authorization", "Bearer testtoken")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -345,6 +345,7 @@ pub async fn list_locks(
     }))
 }
 
+#[allow(dead_code)]
 pub async fn list_user_locks(
     State(state): State<crate::AppState>,
     headers: HeaderMap,

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Open one SQLite connection shared by both AuthService and LockStore (#19)
     let db: DbConn = Arc::new(Mutex::new(rusqlite::Connection::open(&config.database_url)?));
+    {
+        let conn = db.lock().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+    }
 
     // Initialize auth service
     let auth_service = AuthService::new(config.clone(), db.clone())?;
@@ -341,8 +345,23 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn health_check() -> &'static str {
-    "OK"
+async fn health_check(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let storage = state
+        .lock_handlers
+        .store
+        .journal_mode()
+        .unwrap_or_else(|_| "unknown".to_string());
+    let db_size_bytes = state
+        .lock_handlers
+        .store
+        .db_size_bytes()
+        .unwrap_or(0);
+
+    Json(serde_json::json!({
+        "healthy": true,
+        "storage": storage,
+        "db_size_bytes": db_size_bytes
+    }))
 }
 
 async fn status_check(State(state): State<AppState>) -> Json<serde_json::Value> {
@@ -545,8 +564,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         
         let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let body_str = std::str::from_utf8(&body).unwrap();
-        assert_eq!(body_str, "OK");
+        let body_json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body_json["healthy"], true);
+        assert_eq!(body_json["storage"], "wal");
+        assert!(body_json["db_size_bytes"].is_number());
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,7 +391,7 @@ async fn admin_status(
     let active_locks = state.lock_handlers.store.get_all_active_locks();
     let locks: Vec<serde_json::Value> = active_locks
         .into_iter()
-        .filter_map(|lock| {
+        .map(|lock| {
             // Get holder username
             let holder_username = state.auth_service
                 .get_user_by_id(&lock.holder_id.to_string())
@@ -405,14 +405,14 @@ async fn admin_status(
                 0
             };
 
-            Some(serde_json::json!({
+            serde_json::json!({
                 "name": lock.name,
                 "holder_username": holder_username,
                 "metadata": lock.metadata,
                 "fencing_token": lock.fencing_token,
                 "expires_at": lock.expires_at.to_rfc3339(),
                 "ttl_remaining_seconds": ttl_remaining
-            }))
+            })
         }).collect();
 
     // Get all registered users

--- a/src/models.rs
+++ b/src/models.rs
@@ -108,11 +108,13 @@ pub struct LockStatusResponse {
 }
 
 #[derive(Debug, Serialize)]
+#[allow(dead_code)]
 pub struct UserLocksResponse {
     pub locks: Vec<UserLockInfo>,
 }
 
 #[derive(Debug, Serialize)]
+#[allow(dead_code)]
 pub struct UserLockInfo {
     pub name: String,
     pub lease_id: Uuid,
@@ -247,6 +249,7 @@ impl From<Webhook> for WebhookResponse {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[allow(dead_code)]
 pub struct WebhookDelivery {
     pub webhook_id: Uuid,
     pub lock_name: String,

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,6 +10,7 @@ pub struct User {
     pub github_id: u64,
     pub github_username: String,
     pub token: String,
+    pub namespace: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -132,6 +133,7 @@ pub struct AuthTokenResponse {
     pub token: String,
     pub user_id: Uuid,
     pub github_username: String,
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -351,7 +353,7 @@ mod tests {
     #[test]
     fn test_lock_is_expired() {
         let now = Utc::now();
-        
+
         // Test expired lock
         let expired_lock = Lock {
             name: "test-lock".to_string(),
@@ -501,7 +503,7 @@ mod tests {
         assert!(validate_metadata(&None).is_ok());
         assert!(validate_metadata(&Some("".to_string())).is_ok());
         assert!(validate_metadata(&Some("short metadata".to_string())).is_ok());
-        
+
         // Exactly 1024 bytes should be OK
         let max_metadata = "a".repeat(1024);
         assert!(validate_metadata(&Some(max_metadata)).is_ok());
@@ -523,8 +525,10 @@ mod tests {
             metadata: Some("test".to_string()),
         };
         let json = serde_json::to_string(&acquired).unwrap();
-        assert!(json.contains("\"status\":\"acquired\""),
-            "acquired variant must serialize with status=acquired");
+        assert!(
+            json.contains("\"status\":\"acquired\""),
+            "acquired variant must serialize with status=acquired"
+        );
 
         let held = AcquireLockResponse::Held {
             holder_id: uuid::Uuid::new_v4(),
@@ -532,17 +536,31 @@ mod tests {
             metadata: None,
         };
         let json = serde_json::to_string(&held).unwrap();
-        assert!(json.contains("\"status\":\"held\""),
-            "held variant must serialize with status=held");
+        assert!(
+            json.contains("\"status\":\"held\""),
+            "held variant must serialize with status=held"
+        );
     }
 
     #[test]
     fn test_boundary_values() {
-        assert!(validate_lock_name(&"a".repeat(64)).is_ok(), "64-char component should be valid");
-        assert!(validate_lock_name(&"a".repeat(65)).is_err(), "65-char component should be rejected");
-        assert!(validate_lock_name(&"a".repeat(256)).is_err(), "256-char single component should be rejected (>64)");
+        assert!(
+            validate_lock_name(&"a".repeat(64)).is_ok(),
+            "64-char component should be valid"
+        );
+        assert!(
+            validate_lock_name(&"a".repeat(65)).is_err(),
+            "65-char component should be rejected"
+        );
+        assert!(
+            validate_lock_name(&"a".repeat(256)).is_err(),
+            "256-char single component should be rejected (>64)"
+        );
         let name_256 = format!("{}/{}", "a".repeat(64), "b".repeat(64));
-        assert!(validate_lock_name(&name_256).is_ok(), "multi-component name within limits should be valid");
+        assert!(
+            validate_lock_name(&name_256).is_ok(),
+            "multi-component name within limits should be valid"
+        );
         assert!(validate_ttl(1).is_ok());
         assert!(validate_ttl(3600).is_ok());
         assert!(validate_ttl(3601).is_err());

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -236,6 +236,7 @@ impl SessionStore {
             .map(|entry| entry.value().clone())
     }
 
+    #[allow(dead_code)]
     pub fn get_user_sessions(&self, user_id: Uuid) -> Vec<Session> {
         self.sessions
             .iter()
@@ -268,7 +269,7 @@ impl SessionStore {
 
         for entry in self.sessions.iter() {
             if entry.value().expires_at <= now {
-                expired.push(entry.key().clone());
+                expired.push(*entry.key());
             }
         }
 
@@ -315,7 +316,7 @@ impl SessionStore {
 }
 
 fn clamp_ttl(ttl: Option<u32>) -> u32 {
-    ttl.unwrap_or(DEFAULT_TTL).max(MIN_TTL).min(MAX_TTL)
+    ttl.unwrap_or(DEFAULT_TTL).clamp(MIN_TTL, MAX_TTL)
 }
 
 // ── Route handlers ──────────────────────────────────────────────────────

--- a/src/store.rs
+++ b/src/store.rs
@@ -395,6 +395,7 @@ impl LockStore {
         sender.subscribe()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn acquire_lock(
         &self,
         name: String,
@@ -572,6 +573,7 @@ impl LockStore {
         self.locks.get(name).map(|entry| entry.value().clone())
     }
 
+    #[allow(dead_code)]
     pub fn get_user_locks(&self, user_id: Uuid) -> Vec<Lock> {
         self.locks
             .iter()
@@ -603,7 +605,7 @@ impl LockStore {
     pub fn list_locks(&self, prefix: Option<&str>) -> Vec<Lock> {
         self.locks
             .iter()
-            .filter(|e| prefix.map_or(true, |p| e.key().starts_with(p)))
+            .filter(|e| prefix.is_none_or(|p| e.key().starts_with(p)))
             .map(|e| e.value().clone())
             .collect()
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,6 @@
 use crate::{
-    error::Result, 
-    models::{Lock, LockEvent, LockEventType}
+    error::Result,
+    models::{Lock, LockEvent, LockEventType},
 };
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
@@ -12,8 +12,8 @@ use std::{
     },
     time::Duration,
 };
-use tokio::time;
 use tokio::sync::broadcast;
+use tokio::time;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -44,6 +44,7 @@ impl LockStore {
         // Create locks table if it doesn't exist
         {
             let conn = db.lock().unwrap();
+            conn.execute_batch("PRAGMA journal_mode=WAL;")?;
             conn.execute(
                 r#"
             CREATE TABLE IF NOT EXISTS locks (
@@ -57,6 +58,16 @@ impl LockStore {
                 session_id TEXT,
                 ephemeral INTEGER NOT NULL DEFAULT 0,
                 lock_delay_seconds INTEGER NOT NULL DEFAULT 0
+            )
+            "#,
+                [],
+            )?;
+            conn.execute(
+                r#"
+            CREATE TABLE IF NOT EXISTS cooling_locks (
+                name TEXT PRIMARY KEY,
+                available_at TEXT NOT NULL,
+                lock_delay_seconds INTEGER NOT NULL
             )
             "#,
                 [],
@@ -76,14 +87,20 @@ impl LockStore {
                 .filter_map(|r| r.ok())
                 .collect();
             if !columns.iter().any(|n| n == "ephemeral") {
-                conn.execute("ALTER TABLE locks ADD COLUMN ephemeral INTEGER NOT NULL DEFAULT 0", [])?;
+                conn.execute(
+                    "ALTER TABLE locks ADD COLUMN ephemeral INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )?;
             }
             if !columns.iter().any(|n| n == "lock_delay_seconds") {
-                conn.execute("ALTER TABLE locks ADD COLUMN lock_delay_seconds INTEGER NOT NULL DEFAULT 0", [])?;
+                conn.execute(
+                    "ALTER TABLE locks ADD COLUMN lock_delay_seconds INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )?;
             }
         }
 
-        info!("Locks table initialized");
+        info!("Locks and cooling_locks tables initialized with WAL mode enabled");
 
         // Create the store instance
         let store = Self {
@@ -94,20 +111,21 @@ impl LockStore {
             cooling_locks: Arc::new(DashMap::new()),
             webhook_store: Arc::new(OnceLock::new()),
         };
-        
+
         // Load existing unexpired locks from database
         store.load_locks_from_database()?;
-        
+        store.load_cooling_locks_from_database()?;
+
         // Update fencing counter based on loaded locks
         store.update_fencing_counter_from_locks()?;
-        
+
         Ok(store)
     }
-    
+
     fn load_locks_from_database(&self) -> Result<()> {
         let db = self.db.lock().unwrap();
         let now = Utc::now();
-        
+
         let mut stmt = db.prepare(
             "SELECT name, holder_id, lease_id, fencing_token, expires_at, metadata, acquired_at, session_id, ephemeral, lock_delay_seconds FROM locks"
         )?;
@@ -120,15 +138,37 @@ impl LockStore {
             let session_id_str: Option<String> = row.get(7)?;
 
             // Map parse errors to rusqlite's InvalidColumnType for propagation
-            let holder_id = Uuid::parse_str(&holder_id_str)
-                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, Box::new(e)))?;
-            let lease_id = Uuid::parse_str(&lease_id_str)
-                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(e)))?;
+            let holder_id = Uuid::parse_str(&holder_id_str).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    1,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
+            let lease_id = Uuid::parse_str(&lease_id_str).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    2,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
             let expires_at = DateTime::parse_from_rfc3339(&expires_at_str)
-                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(e)))?
+                .map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        4,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?
                 .with_timezone(&chrono::Utc);
             let acquired_at = DateTime::parse_from_rfc3339(&acquired_at_str)
-                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(e)))?
+                .map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        6,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?
                 .with_timezone(&chrono::Utc);
             let session_id = session_id_str.and_then(|s| Uuid::parse_str(&s).ok());
             let ephemeral: bool = row.get::<_, i64>(8).unwrap_or(0) != 0;
@@ -147,14 +187,14 @@ impl LockStore {
                 lock_delay_seconds,
             })
         })?;
-        
+
         let mut loaded_count = 0;
         let mut expired_count = 0;
         let mut expired_names = Vec::new();
-        
+
         for lock_result in lock_rows {
             let lock = lock_result?;
-            
+
             if lock.expires_at > now {
                 // Lock is still valid, load it into memory
                 self.locks.insert(lock.name.clone(), lock);
@@ -165,39 +205,83 @@ impl LockStore {
                 expired_count += 1;
             }
         }
-        
+
         // Clean up expired locks from database
         if !expired_names.is_empty() {
             for name in expired_names {
                 if let Err(e) = db.execute("DELETE FROM locks WHERE name = ?", params![name]) {
-                    warn!("Failed to delete expired lock {} from database: {}", name, e);
+                    warn!(
+                        "Failed to delete expired lock {} from database: {}",
+                        name, e
+                    );
                 }
             }
         }
-        
+
         info!(
-            "Loaded {} active locks from database, cleaned up {} expired locks", 
+            "Loaded {} active locks from database, cleaned up {} expired locks",
             loaded_count, expired_count
         );
-        
+
         Ok(())
     }
-    
+
+    fn load_cooling_locks_from_database(&self) -> Result<()> {
+        let db = self.db.lock().unwrap();
+        let now = Utc::now();
+
+        let mut stmt =
+            db.prepare("SELECT name, available_at, lock_delay_seconds FROM cooling_locks")?;
+        let rows = stmt.query_map([], |row| {
+            let name: String = row.get(0)?;
+            let available_at_str: String = row.get(1)?;
+            let lock_delay_seconds: i64 = row.get(2)?;
+            Ok((name, available_at_str, lock_delay_seconds))
+        })?;
+
+        let mut expired = Vec::new();
+        for row in rows {
+            let (name, available_at_str, lock_delay_seconds) = row?;
+            let available_at = DateTime::parse_from_rfc3339(&available_at_str)
+                .map_err(|e| crate::error::AppError::Internal(anyhow::anyhow!(e)))?
+                .with_timezone(&Utc);
+            if available_at > now {
+                self.cooling_locks
+                    .insert(name, (available_at, lock_delay_seconds as u32));
+            } else {
+                expired.push(name);
+            }
+        }
+        drop(stmt);
+
+        for name in expired {
+            db.execute("DELETE FROM cooling_locks WHERE name = ?", params![name])?;
+        }
+
+        Ok(())
+    }
+
     fn update_fencing_counter_from_locks(&self) -> Result<()> {
         let mut max_fencing_token = 0u64;
-        
+
         for entry in self.locks.iter() {
             let lock = entry.value();
             if lock.fencing_token > max_fencing_token {
                 max_fencing_token = lock.fencing_token;
             }
         }
-        
+
         // Set fencing counter to max + 1, but don't go lower than current value
-        let new_counter = std::cmp::max(max_fencing_token + 1, self.fencing_counter.load(Ordering::SeqCst));
+        let new_counter = std::cmp::max(
+            max_fencing_token + 1,
+            self.fencing_counter.load(Ordering::SeqCst),
+        );
         self.fencing_counter.store(new_counter, Ordering::SeqCst);
-        
-        info!("Updated fencing counter to {} based on existing locks", new_counter);
+
+        info!(
+            "Updated fencing counter to {} based on existing locks",
+            new_counter
+        );
         Ok(())
     }
 
@@ -205,7 +289,7 @@ impl LockStore {
         tokio::spawn(async move {
             let mut interval = time::interval(Duration::from_secs(5));
             info!("Started lock expiry background task (5s interval)");
-            
+
             loop {
                 interval.tick().await;
                 self.cleanup_expired_locks().await;
@@ -225,6 +309,12 @@ impl LockStore {
             .collect();
         for name in expired_cooling {
             self.cooling_locks.remove(&name);
+            if let Err(e) = self.delete_cooling_lock_from_database(&name) {
+                warn!(
+                    "Failed to delete cooling lock {} from database: {}",
+                    name, e
+                );
+            }
         }
 
         let mut expired_locks = Vec::new();
@@ -239,8 +329,20 @@ impl LockStore {
             if let Some((_, lock)) = self.locks.remove(&lock_name) {
                 // Start cooling period if lock has a delay
                 if lock.lock_delay_seconds > 0 {
-                    let available_at = now + chrono::Duration::seconds(lock.lock_delay_seconds as i64);
-                    self.cooling_locks.insert(lock_name.clone(), (available_at, lock.lock_delay_seconds));
+                    let available_at =
+                        now + chrono::Duration::seconds(lock.lock_delay_seconds as i64);
+                    self.cooling_locks
+                        .insert(lock_name.clone(), (available_at, lock.lock_delay_seconds));
+                    if let Err(e) = self.save_cooling_lock_to_database(
+                        &lock_name,
+                        available_at,
+                        lock.lock_delay_seconds,
+                    ) {
+                        warn!(
+                            "Failed to save cooling lock {} to database: {}",
+                            lock_name, e
+                        );
+                    }
                 }
 
                 debug!("Expired lock: {} (holder: {})", lock_name, lock.holder_id);
@@ -255,7 +357,10 @@ impl LockStore {
 
                 // Also remove from database
                 if let Err(e) = self.delete_lock_from_database(&lock_name) {
-                    warn!("Failed to delete expired lock {} from database: {}", lock_name, e);
+                    warn!(
+                        "Failed to delete expired lock {} from database: {}",
+                        lock_name, e
+                    );
                 }
             }
         }
@@ -280,10 +385,13 @@ impl LockStore {
 
     /// Returns a broadcast receiver for real-time events on a specific lock.
     pub fn watch_lock(&self, name: &str) -> broadcast::Receiver<LockEvent> {
-        let sender = self.watch_channels.entry(name.to_string()).or_insert_with(|| {
-            let (tx, _) = broadcast::channel(100);
-            tx
-        });
+        let sender = self
+            .watch_channels
+            .entry(name.to_string())
+            .or_insert_with(|| {
+                let (tx, _) = broadcast::channel(100);
+                tx
+            });
         sender.subscribe()
     }
 
@@ -318,12 +426,12 @@ impl LockStore {
                     lock_delay_seconds,
                 };
                 entry.insert(lock.clone());
-                
+
                 // Persist to database
                 if let Err(e) = self.save_lock_to_database(&lock) {
                     warn!("Failed to save lock {} to database: {}", name, e);
                 }
-                
+
                 // Broadcast acquisition
                 self.broadcast_event(LockEvent {
                     event: LockEventType::Acquired,
@@ -331,12 +439,12 @@ impl LockStore {
                     lock: Some(lock),
                     timestamp: now,
                 });
-                
+
                 Ok((lease_id, fencing_token, expires_at))
             }
             dashmap::mapref::entry::Entry::Occupied(mut entry) => {
                 let existing_lock = entry.get();
-                
+
                 // If expired, replace it
                 if existing_lock.is_expired() {
                     let lock = Lock {
@@ -352,7 +460,7 @@ impl LockStore {
                         lock_delay_seconds,
                     };
                     entry.insert(lock.clone());
-                    
+
                     // Persist to database
                     if let Err(e) = self.save_lock_to_database(&lock) {
                         warn!("Failed to save lock {} to database: {}", name, e);
@@ -365,12 +473,16 @@ impl LockStore {
                         lock: Some(lock),
                         timestamp: now,
                     });
-                    
+
                     Ok((lease_id, fencing_token, expires_at))
                 }
                 // If held by same user, return existing lease info (idempotent)
                 else if existing_lock.holder_id == holder_id {
-                    Ok((existing_lock.lease_id, existing_lock.fencing_token, existing_lock.expires_at))
+                    Ok((
+                        existing_lock.lease_id,
+                        existing_lock.fencing_token,
+                        existing_lock.expires_at,
+                    ))
                 }
                 // Otherwise, lock is held by someone else
                 else {
@@ -390,7 +502,13 @@ impl LockStore {
                 // Start cooling period if lock has a delay
                 if lock_delay > 0 {
                     let available_at = Utc::now() + chrono::Duration::seconds(lock_delay as i64);
-                    self.cooling_locks.insert(name.to_string(), (available_at, lock_delay));
+                    self.cooling_locks
+                        .insert(name.to_string(), (available_at, lock_delay));
+                    if let Err(e) =
+                        self.save_cooling_lock_to_database(name, available_at, lock_delay)
+                    {
+                        warn!("Failed to save cooling lock {} to database: {}", name, e);
+                    }
                 }
 
                 // Broadcast release
@@ -409,7 +527,9 @@ impl LockStore {
                 Ok(())
             }
             Some(_) => Err(crate::error::AppError::InvalidLeaseId),
-            None => Err(crate::error::AppError::LockNotFound { name: name.to_string() }),
+            None => Err(crate::error::AppError::LockNotFound {
+                name: name.to_string(),
+            }),
         }
     }
 
@@ -425,7 +545,7 @@ impl LockStore {
                 let now = Utc::now();
                 let new_expires_at = now + chrono::Duration::seconds(ttl_seconds as i64);
                 lock.expires_at = new_expires_at;
-                
+
                 // Update database with new expiry time
                 if let Err(e) = self.save_lock_to_database(&lock.clone()) {
                     warn!("Failed to update lock {} in database: {}", name, e);
@@ -438,11 +558,13 @@ impl LockStore {
                     lock: Some(lock.clone()),
                     timestamp: now,
                 });
-                
+
                 Ok(new_expires_at)
             }
             Some(_) => Err(crate::error::AppError::InvalidLeaseId),
-            None => Err(crate::error::AppError::LockNotFound { name: name.to_string() }),
+            None => Err(crate::error::AppError::LockNotFound {
+                name: name.to_string(),
+            }),
         }
     }
 
@@ -511,8 +633,20 @@ impl LockStore {
         for lock_name in to_remove {
             if let Some((_, lock)) = self.locks.remove(&lock_name) {
                 if lock.lock_delay_seconds > 0 {
-                    let available_at = Utc::now() + chrono::Duration::seconds(lock.lock_delay_seconds as i64);
-                    self.cooling_locks.insert(lock_name.clone(), (available_at, lock.lock_delay_seconds));
+                    let available_at =
+                        Utc::now() + chrono::Duration::seconds(lock.lock_delay_seconds as i64);
+                    self.cooling_locks
+                        .insert(lock_name.clone(), (available_at, lock.lock_delay_seconds));
+                    if let Err(e) = self.save_cooling_lock_to_database(
+                        &lock_name,
+                        available_at,
+                        lock.lock_delay_seconds,
+                    ) {
+                        warn!(
+                            "Failed to save cooling lock {} to database: {}",
+                            lock_name, e
+                        );
+                    }
                 }
                 debug!(
                     "Released lock {} (session {} expired)",
@@ -549,6 +683,12 @@ impl LockStore {
             } else {
                 drop(entry);
                 self.cooling_locks.remove(name);
+                if let Err(e) = self.delete_cooling_lock_from_database(name) {
+                    warn!(
+                        "Failed to delete cooling lock {} from database: {}",
+                        name, e
+                    );
+                }
             }
         }
         None
@@ -573,11 +713,44 @@ impl LockStore {
         )?;
         Ok(())
     }
-    
+
     fn delete_lock_from_database(&self, name: &str) -> Result<()> {
         let db = self.db.lock().unwrap();
         db.execute("DELETE FROM locks WHERE name = ?", params![name])?;
         Ok(())
+    }
+
+    fn save_cooling_lock_to_database(
+        &self,
+        name: &str,
+        available_at: DateTime<Utc>,
+        lock_delay_seconds: u32,
+    ) -> Result<()> {
+        let db = self.db.lock().unwrap();
+        db.execute(
+            "INSERT OR REPLACE INTO cooling_locks (name, available_at, lock_delay_seconds) VALUES (?, ?, ?)",
+            params![name, available_at.to_rfc3339(), lock_delay_seconds as i64],
+        )?;
+        Ok(())
+    }
+
+    fn delete_cooling_lock_from_database(&self, name: &str) -> Result<()> {
+        let db = self.db.lock().unwrap();
+        db.execute("DELETE FROM cooling_locks WHERE name = ?", params![name])?;
+        Ok(())
+    }
+
+    pub fn journal_mode(&self) -> Result<String> {
+        let db = self.db.lock().unwrap();
+        let mode: String = db.pragma_query_value(None, "journal_mode", |row| row.get(0))?;
+        Ok(mode)
+    }
+
+    pub fn db_size_bytes(&self) -> Result<u64> {
+        let db = self.db.lock().unwrap();
+        let page_count: u64 = db.pragma_query_value(None, "page_count", |row| row.get(0))?;
+        let page_size: u64 = db.pragma_query_value(None, "page_size", |row| row.get(0))?;
+        Ok(page_count.saturating_mul(page_size))
     }
 }
 
@@ -589,7 +762,7 @@ mod tests {
     use std::time::Duration;
     use tempfile::NamedTempFile;
     use tokio::time::{sleep, Duration as TokioDuration};
-    
+
     fn make_db(path: &str) -> DbConn {
         let conn = Connection::open(path).expect("Failed to open DB");
         Arc::new(std::sync::Mutex::new(conn))
@@ -610,29 +783,37 @@ mod tests {
     async fn test_locks_survive_restart_simulation() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id = Uuid::new_v4();
         let lock_name = "test-lock-restart".to_string();
         let metadata = Some("test metadata".to_string());
-        
+
         // Create first store and acquire a lock
         {
             let store1 = create_test_store_with_path(&db_path);
-            let result = store1.acquire_lock(lock_name.clone(), holder_id, 300, metadata.clone(), None, false, 0);
+            let result = store1.acquire_lock(
+                lock_name.clone(),
+                holder_id,
+                300,
+                metadata.clone(),
+                None,
+                false,
+                0,
+            );
             assert!(result.is_ok());
             let (_lease_id, fencing_token, _) = result.unwrap();
             assert_eq!(fencing_token, 1);
-            
+
             // Verify the lock is in memory
             let lock = store1.get_lock(&lock_name);
             assert!(lock.is_some());
             assert_eq!(lock.unwrap().holder_id, holder_id);
         } // store1 goes out of scope, simulating restart
-        
+
         // Create second store from same DB path - should load the lock
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Verify the lock was restored from database
             let lock = store2.get_lock(&lock_name);
             assert!(lock.is_some());
@@ -649,38 +830,41 @@ mod tests {
     async fn test_fencing_counter_restores() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id1 = Uuid::new_v4();
         let holder_id2 = Uuid::new_v4();
-        
+
         // Create first store and acquire multiple locks
         {
             let store1 = create_test_store_with_path(&db_path);
-            
+
             // Acquire first lock (should get fencing token 1)
-            let result1 = store1.acquire_lock("lock-1".to_string(), holder_id1, 300, None, None, false, 0);
+            let result1 =
+                store1.acquire_lock("lock-1".to_string(), holder_id1, 300, None, None, false, 0);
             assert!(result1.is_ok());
             let (_, fencing_token1, _) = result1.unwrap();
             assert_eq!(fencing_token1, 1);
-            
+
             // Acquire second lock (should get fencing token 2)
-            let result2 = store1.acquire_lock("lock-2".to_string(), holder_id2, 300, None, None, false, 0);
+            let result2 =
+                store1.acquire_lock("lock-2".to_string(), holder_id2, 300, None, None, false, 0);
             assert!(result2.is_ok());
             let (_, fencing_token2, _) = result2.unwrap();
             assert_eq!(fencing_token2, 2);
-            
+
             assert_eq!(store1.get_fencing_counter(), 3);
         }
-        
+
         // Create second store from same DB - fencing counter should be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Fencing counter should be max existing token + 1 = 3
             assert_eq!(store2.get_fencing_counter(), 3);
-            
+
             // Acquire a new lock - should get fencing token 3
-            let result3 = store2.acquire_lock("lock-3".to_string(), holder_id1, 300, None, None, false, 0);
+            let result3 =
+                store2.acquire_lock("lock-3".to_string(), holder_id1, 300, None, None, false, 0);
             assert!(result3.is_ok());
             let (_, fencing_token3, _) = result3.unwrap();
             assert_eq!(fencing_token3, 3);
@@ -691,34 +875,35 @@ mod tests {
     async fn test_expired_locks_not_restored() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id = Uuid::new_v4();
         let lock_name = "test-lock-expiry".to_string();
-        
+
         // Create first store and acquire a lock with very short TTL
         {
             let store1 = create_test_store_with_path(&db_path);
             let result = store1.acquire_lock(lock_name.clone(), holder_id, 1, None, None, false, 0); // 1 second TTL
             assert!(result.is_ok());
-            
+
             // Verify lock is initially present
             let lock = store1.get_lock(&lock_name);
             assert!(lock.is_some());
         }
-        
+
         // Wait for lock to expire
         sleep(TokioDuration::from_secs(2)).await;
-        
+
         // Create second store - expired lock should not be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Expired lock should not be in memory
             let lock = store2.get_lock(&lock_name);
             assert!(lock.is_none());
-            
+
             // Should be able to acquire the same lock name (it's free)
-            let result = store2.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
+            let result =
+                store2.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
             assert!(result.is_ok());
         }
     }
@@ -727,43 +912,45 @@ mod tests {
     async fn test_release_removes_from_sqlite() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id = Uuid::new_v4();
         let lock_name = "test-lock-release".to_string();
-        
+
         let lease_id;
-        
+
         // Create first store, acquire and release a lock
         {
             let store1 = create_test_store_with_path(&db_path);
-            let result = store1.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
+            let result =
+                store1.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
             assert!(result.is_ok());
             let (acquired_lease_id, _, _) = result.unwrap();
             lease_id = acquired_lease_id;
-            
+
             // Verify lock is present
             let lock = store1.get_lock(&lock_name);
             assert!(lock.is_some());
-            
+
             // Release the lock
             let release_result = store1.release_lock(&lock_name, lease_id, holder_id);
             assert!(release_result.is_ok());
-            
+
             // Verify lock is gone from memory
             let lock = store1.get_lock(&lock_name);
             assert!(lock.is_none());
         }
-        
+
         // Create second store - released lock should not be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Released lock should not be in memory
             let lock = store2.get_lock(&lock_name);
             assert!(lock.is_none());
-            
+
             // Should be able to acquire the same lock name (it's free)
-            let result = store2.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
+            let result =
+                store2.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
             assert!(result.is_ok());
         }
     }
@@ -772,15 +959,23 @@ mod tests {
     async fn test_metadata_persists() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id = Uuid::new_v4();
         let lock_name = "test-lock-metadata".to_string();
         let metadata = Some("important lock metadata with special chars: éñ中文".to_string());
-        
+
         // Create first store and acquire a lock with metadata
         {
             let store1 = create_test_store_with_path(&db_path);
-            let result = store1.acquire_lock(lock_name.clone(), holder_id, 300, metadata.clone(), None, false, 0);
+            let result = store1.acquire_lock(
+                lock_name.clone(),
+                holder_id,
+                300,
+                metadata.clone(),
+                None,
+                false,
+                0,
+            );
             assert!(result.is_ok());
 
             // Verify metadata is correct in memory
@@ -788,11 +983,11 @@ mod tests {
             assert!(lock.is_some());
             assert_eq!(lock.unwrap().metadata, metadata);
         }
-        
+
         // Create second store - metadata should be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Metadata should be intact after restore
             let lock = store2.get_lock(&lock_name);
             assert!(lock.is_some());
@@ -805,21 +1000,21 @@ mod tests {
     async fn test_multiple_locks_persist() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id1 = Uuid::new_v4();
         let holder_id2 = Uuid::new_v4();
         let holder_id3 = Uuid::new_v4();
-        
+
         let locks_data = vec![
             ("lock-alpha", holder_id1, "metadata for alpha"),
-            ("lock-beta", holder_id2, "metadata for beta"), 
+            ("lock-beta", holder_id2, "metadata for beta"),
             ("lock-gamma", holder_id3, "metadata for gamma"),
         ];
-        
+
         // Create first store and acquire multiple locks
         {
             let store1 = create_test_store_with_path(&db_path);
-            
+
             for (lock_name, holder_id, metadata) in &locks_data {
                 let result = store1.acquire_lock(
                     lock_name.to_string(),
@@ -832,19 +1027,19 @@ mod tests {
                 );
                 assert!(result.is_ok());
             }
-            
+
             // Verify all locks are in memory
             assert_eq!(store1.get_all_active_locks().len(), 3);
         }
-        
+
         // Create second store - all locks should be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // All locks should be restored
             let all_locks = store2.get_all_active_locks();
             assert_eq!(all_locks.len(), 3);
-            
+
             // Verify each lock individually
             for (lock_name, expected_holder_id, expected_metadata) in &locks_data {
                 let lock = store2.get_lock(lock_name);
@@ -860,19 +1055,19 @@ mod tests {
     async fn test_concurrent_acquire_release_with_persistence() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         // Test concurrent operations on the same store
         {
             let store = Arc::new(create_test_store_with_path(&db_path));
             let mut handles = vec![];
-            
+
             // Spawn multiple threads that acquire and release locks
             for i in 0..10 {
                 let store_clone = Arc::clone(&store);
                 let handle = thread::spawn(move || {
                     let holder_id = Uuid::new_v4();
                     let lock_name = format!("concurrent-lock-{}", i);
-                    
+
                     // Acquire lock
                     let acquire_result = store_clone.acquire_lock(
                         lock_name.clone(),
@@ -884,50 +1079,62 @@ mod tests {
                         0,
                     );
                     if acquire_result.is_err() {
-                        return Err(format!("Failed to acquire lock {}: {:?}", lock_name, acquire_result.err()));
+                        return Err(format!(
+                            "Failed to acquire lock {}: {:?}",
+                            lock_name,
+                            acquire_result.err()
+                        ));
                     }
-                    
+
                     let (lease_id, fencing_token, _) = acquire_result.unwrap();
-                    
+
                     // Small delay to simulate work
                     thread::sleep(Duration::from_millis(10));
-                    
+
                     // Release lock
                     let release_result = store_clone.release_lock(&lock_name, lease_id, holder_id);
                     if release_result.is_err() {
-                        return Err(format!("Failed to release lock {}: {:?}", lock_name, release_result.err()));
+                        return Err(format!(
+                            "Failed to release lock {}: {:?}",
+                            lock_name,
+                            release_result.err()
+                        ));
                     }
-                    
+
                     Ok(fencing_token)
                 });
-                
+
                 handles.push(handle);
             }
-            
+
             // Collect results
             let mut fencing_tokens = vec![];
             for handle in handles {
                 let result = handle.join().expect("Thread panicked");
-                assert!(result.is_ok(), "Thread operation failed: {:?}", result.err());
+                assert!(
+                    result.is_ok(),
+                    "Thread operation failed: {:?}",
+                    result.err()
+                );
                 fencing_tokens.push(result.unwrap());
             }
-            
+
             // Verify we got unique fencing tokens
             fencing_tokens.sort();
             let expected_tokens: Vec<u64> = (1..=10).collect();
             assert_eq!(fencing_tokens, expected_tokens);
-            
+
             // Verify no locks remain
             assert_eq!(store.get_all_active_locks().len(), 0);
         }
-        
+
         // Create second store - should have no locks and correct fencing counter
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // No locks should be restored (all were released)
             assert_eq!(store2.get_all_active_locks().len(), 0);
-            
+
             // Note: Current implementation resets fencing counter when no locks exist
             // In a production system, you might want to persist the max fencing token separately
             // For now, we test the current behavior
@@ -940,18 +1147,18 @@ mod tests {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
         let lock_name = "contested-lock";
-        
+
         {
             let store = Arc::new(create_test_store_with_path(&db_path));
             let mut handles = vec![];
-            
+
             // Spawn multiple threads trying to acquire the same lock
             for i in 0..5 {
                 let store_clone = Arc::clone(&store);
                 let lock_name_clone = lock_name.to_string();
                 let handle = thread::spawn(move || {
                     let holder_id = Uuid::new_v4();
-                    
+
                     let acquire_result = store_clone.acquire_lock(
                         lock_name_clone,
                         holder_id,
@@ -961,44 +1168,80 @@ mod tests {
                         false,
                         0,
                     );
-                    
+
                     (holder_id, acquire_result)
                 });
-                
+
                 handles.push(handle);
             }
-            
+
             // Collect results - only one should succeed
             let mut successful_acquisitions = 0;
             let mut successful_holder: Option<Uuid> = None;
-            
+
             for handle in handles {
                 let (holder_id, result) = handle.join().expect("Thread panicked");
-                
+
                 if result.is_ok() {
                     successful_acquisitions += 1;
                     successful_holder = Some(holder_id);
                 }
             }
-            
+
             // Exactly one thread should have acquired the lock
             assert_eq!(successful_acquisitions, 1);
             assert!(successful_holder.is_some());
-            
+
             // Verify the winning lock is in memory
             let lock = store.get_lock(lock_name);
             assert!(lock.is_some());
             assert_eq!(lock.unwrap().holder_id, successful_holder.unwrap());
         }
-        
+
         // Create second store - the winning lock should be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             let lock = store2.get_lock(lock_name);
             assert!(lock.is_some());
             // The lock should belong to the winning holder from before
             assert!(!lock.unwrap().is_expired());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cooling_locks_survive_restart() {
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let db_path = temp_file.path().to_string_lossy().to_string();
+        let holder_id = Uuid::new_v4();
+        let lock_name = "cooling-restart-lock";
+
+        {
+            let store1 = create_test_store_with_path(&db_path);
+            let (lease_id, _, _) = store1
+                .acquire_lock(lock_name.to_string(), holder_id, 60, None, None, false, 30)
+                .expect("acquire should succeed");
+
+            store1
+                .release_lock(lock_name, lease_id, holder_id)
+                .expect("release should succeed");
+
+            assert!(store1.check_cooling(lock_name).is_some());
+        }
+
+        {
+            let store2 = create_test_store_with_path(&db_path);
+            assert!(store2.check_cooling(lock_name).is_some());
+
+            let _result = store2.acquire_lock(
+                lock_name.to_string(),
+                Uuid::new_v4(),
+                60,
+                None,
+                None,
+                false,
+                0,
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- enable SQLite WAL mode at startup and in lock-store initialization for durable write-ahead recovery
- persist cooling_locks to SQLite and reload them on boot so lock-delay state survives restarts
- upgrade /health to structured JSON with healthy, storage, and db_size_bytes
- update OpenAPI + README docs to match the health response

## Testing
- cargo test test_health_check
- cargo test test_cooling_locks_survive_restart
- cargo test test_locks_survive_restart_simulation

Fixes #23