### PR TITLE
fix: resolve remaining namespace test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All lock endpoints require `Authorization: Bearer <token>`.
 | `GET` | `/locks/{name}` | Check lock status |
 | `GET` | `/locks` | List your locks |
 | `GET` | `/docs` | Interactive API docs |
-| `GET` | `/health` | Health check |
+| `GET` | `/health` | Health check + storage details |
 
 ### Acquire
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,90 @@
 # 🐙 OctoStore
 
-Distributed locking as a service. One binary, simple HTTP API, SQLite persistence.
+**Self-hostable coordination over HTTP**
+
+OctoStore is a self-hostable distributed lock and lease service over HTTP.
+Use it locally or across many machines to coordinate work with visible ownership and automatic recovery.
 
 > **Alpha software.** API may change. AI-assisted development. No SLA.
 
-## What it does
+## What it is
 
-OctoStore gives you distributed locks over HTTP with monotonically increasing
-fencing tokens. No etcd, no ZooKeeper, no Consul — just a single Rust binary.
+OctoStore is a narrow primitive:
+- claim a stable job name
+- renew while the owner is alive
+- release when done
+- let ownership expire automatically on failure
 
-Sign up with GitHub → get a bearer token → start locking.
+That makes it useful for:
+- local scripts and cron jobs
+- background workers
+- CI/CD deploy serialization
+- multi-machine services
+- agent runtimes
+
+## Why it exists
+
+Without a shared lock or lease layer, distributed systems tend to drift into the same failures:
+- duplicate work
+- invisible ownership
+- blind retries
+- stuck work after crashes
+- ad hoc coordination logic spread across many services
+
+OctoStore gives you one clean coordination primitive instead.
+
+## Local and multi-machine coordination
+
+### Local coordination
+Run OctoStore on one machine and let local processes coordinate through it.
+
+Good for:
+- several workers on one box
+- cron dedup
+- local agents
+- dev and demo environments
+
+### Multi-machine coordination
+Run one shared OctoStore deployment and let workers across many servers coordinate through the same API.
+
+Good for:
+- shared job processing
+- deploy locks
+- cross-machine cron dedup
+- fleet-wide visibility into what is running where
+
+## Coordination pattern
+
+The practical pattern is simple:
+1. choose one stable name for one logical unit of work
+2. have all workers try to claim the same name
+3. attach metadata about the owner
+4. renew while active
+5. release on completion
+6. let TTL expiry recover from crashes
+
+Recommended metadata includes:
+- `owner`
+- `host`
+- `service`
+- `task_id`
+- `job`
+- `claimed_at`
+- `run_id`
+- `run_url`
+
+## Example
+
+Five workers can all see `github/issues/123`.
+Only one should do the work.
+
+With OctoStore:
+1. each worker tries to claim the same stable job name
+2. one worker wins
+3. the others inspect the owner metadata and back off
+4. the winner renews while working
+5. if the winner crashes, the claim expires
+6. another worker can take over
 
 ## Quick start
 
@@ -19,14 +94,11 @@ Sign up with GitHub → get a bearer token → start locking.
 # Sign in with GitHub (opens browser)
 open https://api.octostore.io/auth/github
 
-# Acquire a lock (60s TTL)
+# Acquire a lock / claim (60s TTL)
 curl -X POST https://api.octostore.io/locks/my-service/acquire \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"ttl_seconds": 60}'
-
-# Response:
-# {"status":"acquired","lease_id":"...","fencing_token":1,"expires_at":"..."}
 ```
 
 ### Self-host
@@ -51,46 +123,13 @@ All lock endpoints require `Authorization: Bearer <token>`.
 |--------|----------|-------------|
 | `GET` | `/auth/github` | Start GitHub OAuth flow |
 | `POST` | `/auth/token/rotate` | Rotate bearer token |
-| `POST` | `/locks/{name}/acquire` | Acquire a lock |
+| `POST` | `/locks/{name}/acquire` | Acquire a lock / job claim |
 | `POST` | `/locks/{name}/release` | Release a lock |
 | `POST` | `/locks/{name}/renew` | Extend lock TTL |
-| `GET` | `/locks/{name}` | Check lock status |
+| `GET` | `/locks/{name}` | Check current owner / lock status |
 | `GET` | `/locks` | List your locks |
 | `GET` | `/docs` | Interactive API docs |
 | `GET` | `/health` | Health check + storage details |
-
-### Acquire
-
-```bash
-curl -X POST https://api.octostore.io/locks/leader/acquire \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"ttl_seconds": 60}'
-```
-
-**Lock acquired:**
-```json
-{"status": "acquired", "lease_id": "uuid", "fencing_token": 42, "expires_at": "..."}
-```
-
-**Already held:**
-```json
-{"status": "held", "holder_id": "other-uuid", "expires_at": "..."}
-```
-
-### Release / Renew
-
-```bash
-# Release
-curl -X POST .../locks/leader/release \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"lease_id": "your-lease-uuid"}'
-
-# Renew
-curl -X POST .../locks/leader/renew \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"lease_id": "your-lease-uuid", "ttl_seconds": 60}'
-```
 
 ## Fencing tokens
 
@@ -102,6 +141,25 @@ UPDATE state SET data = ?, fence = ? WHERE fence < ?
 ```
 
 This is what makes the locking actually safe, unlike Redlock.
+
+## Good fit
+
+OctoStore works well for:
+- local coordination on one machine
+- multi-machine workers sharing jobs
+- deploy serialization
+- background workers on shared queues
+- agent systems that need one owner per task
+
+## What it is not
+
+OctoStore is not trying to be:
+- a workflow engine
+- a queue
+- a scheduler
+- a giant orchestration control plane
+
+It is the coordination primitive underneath those higher-level patterns.
 
 ## Constraints
 
@@ -122,31 +180,18 @@ Single process. Locks live in memory for speed, replayed from SQLite on restart.
 ## Testing & Quality
 
 ```bash
-cargo test                           # Run all unit + integration tests  
-cargo bench                          # Run criterion benchmarks
-cargo tarpaulin --skip-clean         # Generate coverage report
-cargo +nightly fuzz run fuzz_lock_name  # Run fuzz testing
+cargo test
+cargo bench
+cargo tarpaulin --skip-clean
+cargo +nightly fuzz run fuzz_lock_name
 ```
 
-### Code Coverage
-![Coverage](https://img.shields.io/badge/coverage-pending-yellow)
+See `BENCHMARKS.md` for detailed performance results and system specifications.
 
-Coverage analysis using `cargo-tarpaulin` to ensure comprehensive test coverage across all modules.
+## Release notes
 
-### Fuzz Testing
-Three dedicated fuzz targets test input handling robustness:
-- `fuzz_lock_name` — Lock name validation with arbitrary strings
-- `fuzz_auth_header` — Authorization header parsing edge cases  
-- `fuzz_json_body` — JSON request body parsing with malformed data
-
-### Benchmarks
-Comprehensive performance testing with Criterion.rs:
-- Single-operation latency (acquire/release)
-- Lock contention under load (2-10 threads)
-- Database persistence overhead
-- HTTP stack performance
-
-See `BENCHMARKS.md` for detailed results and system specifications.
+- `v0.10.0` — coordination-first positioning, broader docs set, docs-first navigation
+- `v0.9.x` — namespace safety, WAL-backed recovery, remaining namespace test cleanup
 
 ## License
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -458,16 +458,26 @@ paths:
       tags:
       - System
       summary: Health check
-      description: Simple health check endpoint
+      description: Health and storage details
       security: []
       responses:
         '200':
           description: Service is healthy
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: OK
+                type: object
+                properties:
+                  healthy:
+                    type: boolean
+                    example: true
+                  storage:
+                    type: string
+                    example: wal
+                  db_size_bytes:
+                    type: integer
+                    format: int64
+                    example: 16384
 components:
   securitySchemes:
     bearerAuth:

--- a/site/docs/agent-coordination.html
+++ b/site/docs/agent-coordination.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Agent coordination with OctoStore</title>
+  <meta name="description" content="Use OctoStore as a general coordination layer for agents across runtimes, including but not limited to OpenClaw." />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#111111; --panel2:#1a1a1b; --text:#e5e5e5; --muted:#a1a1aa; --white:#fff; --accent:#6366f1; --border:rgba(255,255,255,0.08); }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif; background:var(--bg); color:var(--text); line-height:1.7; }
+    .container { max-width:980px; margin:0 auto; padding:0 24px; }
+    nav { display:flex; justify-content:space-between; align-items:center; padding:16px 0; border-bottom:1px solid var(--border); margin-bottom:48px; gap:16px; }
+    .brand { color:var(--white); text-decoration:none; font-weight:700; }
+    .nav-links { display:flex; gap:12px; flex-wrap:wrap; }
+    .nav-links a { color:var(--muted); text-decoration:none; padding:8px 14px; border-radius:8px; }
+    .nav-links a:hover, .nav-links a.active { color:var(--white); background:rgba(255,255,255,0.06); }
+    header { padding:32px 0 36px; }
+    h1 { font-size:3rem; line-height:1.08; letter-spacing:-0.03em; color:var(--white); margin-bottom:18px; }
+    .lede { font-size:1.18rem; color:var(--muted); max-width:840px; }
+    section { background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:32px; margin:24px 0; }
+    h2 { color:var(--white); font-size:1.8rem; margin-bottom:12px; }
+    p { margin:12px 0; }
+    ul, ol { margin:12px 0 12px 22px; }
+    li { margin:8px 0; }
+    pre { background:#0d1117; border:1px solid rgba(99,102,241,0.15); border-radius:12px; padding:18px; overflow-x:auto; margin-top:14px; }
+    .pager { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; margin:28px 0 56px; }
+    .pager a { display:block; background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px; color:var(--text); text-decoration:none; }
+    .pager a span { display:block; color:var(--muted); font-size:0.9rem; margin-bottom:4px; }
+    .pager a strong { color:var(--white); font-size:1.02rem; }
+    .pager a:hover { border-color:rgba(99,102,241,0.35); background:rgba(255,255,255,0.03); }
+    @media (max-width:900px){ h1{font-size:2.3rem;} .lede{font-size:1.05rem;} }
+    @media (max-width:700px){ .pager{grid-template-columns:1fr;} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a class="brand" href="/">🐙 OctoStore</a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/" class="active">Docs</a>
+        <a href="/docs/coordination-patterns.html">Coordination guide</a>
+      </div>
+    </nav>
+
+    <header>
+      <h1>Agent coordination with OctoStore</h1>
+      <p class="lede">OctoStore is not an agent framework. It is a lock and lease service that agents can use to coordinate work across many runtimes.</p>
+    </header>
+
+    <section>
+      <h2>The pattern</h2>
+      <p>If several agents can all see the same task, they should all try to claim the same stable job name.</p>
+      <ul>
+        <li>one agent wins</li>
+        <li>the others inspect owner metadata and back off</li>
+        <li>if the winning agent dies, the claim expires</li>
+        <li>another agent can take over</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>General coordination skill</h2>
+      <p>A reusable coordination layer for agents should expose a very small surface:</p>
+      <ul>
+        <li>claim job</li>
+        <li>renew claim</li>
+        <li>release job</li>
+        <li>inspect owner</li>
+        <li>list active jobs</li>
+      </ul>
+      <p>That can be implemented in OpenClaw, Python workers, TypeScript services, MCP servers, or custom runtimes.</p>
+    </section>
+
+    <section>
+      <h2>Example metadata</h2>
+      <pre><code>{
+  "owner": "research-agent-2",
+  "host": "server-b",
+  "service": "agent-runtime",
+  "task_id": "issue-123",
+  "job": "triage GitHub issue",
+  "claimed_at": "2026-04-01T04:08:00Z",
+  "run_id": "agent-run-331",
+  "run_url": "https://ops.example/agents/331"
+}</code></pre>
+    </section>
+
+    <section>
+      <h2>The key point</h2>
+      <p>OpenClaw can use OctoStore. So can anything else.</p>
+      <p>The coordination pattern is general. It should not be documented as OpenClaw-only.</p>
+    </section>
+
+    <div class="pager">
+      <a href="/docs/multi-machine-coordination.html"><span>Previous</span><strong>Multi-machine coordination</strong></a>
+      <a href="/docs/examples.html"><span>Next</span><strong>Examples</strong></a>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/docs/coordination-patterns.html
+++ b/site/docs/coordination-patterns.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Coordination patterns with OctoStore</title>
+  <meta name="description" content="How OctoStore locks and leases become shared work ownership with stable job names, metadata, renewal, release, and TTL-based recovery." />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#111111; --panel2:#1a1a1b; --text:#e5e5e5; --muted:#a1a1aa; --white:#fff; --accent:#6366f1; --border:rgba(255,255,255,0.08); }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif; background:var(--bg); color:var(--text); line-height:1.7; }
+    .container { max-width:980px; margin:0 auto; padding:0 24px; }
+    nav { display:flex; justify-content:space-between; align-items:center; padding:16px 0; border-bottom:1px solid var(--border); margin-bottom:48px; gap:16px; }
+    .brand { color:var(--white); text-decoration:none; font-weight:700; }
+    .nav-links { display:flex; gap:12px; flex-wrap:wrap; }
+    .nav-links a { color:var(--muted); text-decoration:none; padding:8px 14px; border-radius:8px; }
+    .nav-links a:hover, .nav-links a.active { color:var(--white); background:rgba(255,255,255,0.06); }
+    header { padding:32px 0 36px; }
+    h1 { font-size:3rem; line-height:1.08; letter-spacing:-0.03em; color:var(--white); margin-bottom:18px; }
+    .lede { font-size:1.18rem; color:var(--muted); max-width:840px; }
+    section { background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:32px; margin:24px 0; }
+    h2 { color:var(--white); font-size:1.8rem; margin-bottom:12px; }
+    p { margin:12px 0; }
+    ul, ol { margin:12px 0 12px 22px; }
+    li { margin:8px 0; }
+    pre { background:#0d1117; border:1px solid rgba(99,102,241,0.15); border-radius:12px; padding:18px; overflow-x:auto; margin-top:14px; }
+    .pager { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; margin:28px 0 56px; }
+    .pager a { display:block; background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px; color:var(--text); text-decoration:none; }
+    .pager a span { display:block; color:var(--muted); font-size:0.9rem; margin-bottom:4px; }
+    .pager a strong { color:var(--white); font-size:1.02rem; }
+    .pager a:hover { border-color:rgba(99,102,241,0.35); background:rgba(255,255,255,0.03); }
+    @media (max-width:900px){ h1{font-size:2.3rem;} .lede{font-size:1.05rem;} }
+    @media (max-width:700px){ .pager{grid-template-columns:1fr;} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a class="brand" href="/">🐙 OctoStore</a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/">Docs</a>
+        <a href="/docs/coordination-patterns.html" class="active">Coordination guide</a>
+      </div>
+    </nav>
+
+    <header>
+      <h1>Coordination patterns with OctoStore</h1>
+      <p class="lede">OctoStore is a lock and lease primitive. With a few conventions, it becomes a simple coordination pattern for workers, agents, services, scripts, and CI jobs.</p>
+    </header>
+
+    <section>
+      <h2>The pattern</h2>
+      <ol>
+        <li>choose one stable job name</li>
+        <li>try to claim it</li>
+        <li>attach metadata about the owner</li>
+        <li>renew while active</li>
+        <li>release on completion</li>
+        <li>let TTL expiry recover from crashes</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Stable names matter</h2>
+      <p>If the same logical work item is visible to multiple workers, they should all try to claim the same name.</p>
+      <ul>
+        <li><code>images/thumbnail/img-123</code></li>
+        <li><code>deploy/prod</code></li>
+        <li><code>github/issues/123</code></li>
+        <li><code>cron/daily-summary/2026-04-01</code></li>
+      </ul>
+      <p>Do not add random suffixes for the same logical task.</p>
+    </section>
+
+    <section>
+      <h2>Metadata turns locks into coordination</h2>
+      <p>A bare lock tells you something is busy. A claim with metadata tells you who owns it, where it is running, and what it is doing.</p>
+      <pre><code>{
+  "owner": "thumbnail-worker",
+  "host": "server-b",
+  "service": "media-pipeline",
+  "task_id": "img-123",
+  "job": "generate thumbnail",
+  "claimed_at": "2026-04-01T03:55:00Z",
+  "run_id": "run-8472",
+  "run_url": "https://ops.example/runs/8472"
+}</code></pre>
+    </section>
+
+    <section>
+      <h2>Fencing tokens make ownership safer</h2>
+      <p>Every acquire returns a monotonically increasing fencing token. Downstream systems can reject stale writers even if a previous holder wakes up late.</p>
+      <pre><code>UPDATE state SET payload = ?, fence = ? WHERE fence &lt; ?;</code></pre>
+      <p>This is how the lock becomes safer than best-effort mutual exclusion.</p>
+    </section>
+
+    <div class="pager">
+      <a href="/docs/overview.html"><span>Previous</span><strong>Overview</strong></a>
+      <a href="/docs/local-coordination.html"><span>Next</span><strong>Local coordination</strong></a>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/docs/examples.html
+++ b/site/docs/examples.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OctoStore examples</title>
+  <meta name="description" content="Examples of local, multi-machine, CI, cron, and agent coordination patterns with OctoStore." />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#111111; --panel2:#1a1a1b; --text:#e5e5e5; --muted:#a1a1aa; --white:#fff; --accent:#6366f1; --border:rgba(255,255,255,0.08); }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif; background:var(--bg); color:var(--text); line-height:1.7; }
+    .container { max-width:980px; margin:0 auto; padding:0 24px; }
+    nav { display:flex; justify-content:space-between; align-items:center; padding:16px 0; border-bottom:1px solid var(--border); margin-bottom:48px; gap:16px; }
+    .brand { color:var(--white); text-decoration:none; font-weight:700; }
+    .nav-links { display:flex; gap:12px; flex-wrap:wrap; }
+    .nav-links a { color:var(--muted); text-decoration:none; padding:8px 14px; border-radius:8px; }
+    .nav-links a:hover, .nav-links a.active { color:var(--white); background:rgba(255,255,255,0.06); }
+    header { padding:32px 0 36px; }
+    h1 { font-size:3rem; line-height:1.08; letter-spacing:-0.03em; color:var(--white); margin-bottom:18px; }
+    .lede { font-size:1.18rem; color:var(--muted); max-width:840px; }
+    section { background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:32px; margin:24px 0; }
+    h2 { color:var(--white); font-size:1.8rem; margin-bottom:12px; }
+    p { margin:12px 0; }
+    ul, ol { margin:12px 0 12px 22px; }
+    li { margin:8px 0; }
+    .pager { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; margin:28px 0 56px; }
+    .pager a { display:block; background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px; color:var(--text); text-decoration:none; }
+    .pager a span { display:block; color:var(--muted); font-size:0.9rem; margin-bottom:4px; }
+    .pager a strong { color:var(--white); font-size:1.02rem; }
+    .pager a:hover { border-color:rgba(99,102,241,0.35); background:rgba(255,255,255,0.03); }
+    @media (max-width:900px){ h1{font-size:2.3rem;} .lede{font-size:1.05rem;} }
+    @media (max-width:700px){ .pager{grid-template-columns:1fr;} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a class="brand" href="/">🐙 OctoStore</a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/" class="active">Docs</a>
+        <a href="/docs/coordination-patterns.html">Coordination guide</a>
+      </div>
+    </nav>
+
+    <header>
+      <h1>OctoStore examples</h1>
+      <p class="lede">Simple examples that show how a distributed lock and lease service becomes a practical coordination layer.</p>
+    </header>
+
+    <section>
+      <h2>Two local workers, one task</h2>
+      <p>Two workers on one machine can both see <code>images/thumbnail/img-123</code>. Both try to claim it. One succeeds. The other reads the owner metadata and skips the task.</p>
+    </section>
+
+    <section>
+      <h2>Five workers, one winner</h2>
+      <p>Five workers all try to claim the same job at once. One wins. Four lose immediately. If the winner stops renewing, the claim expires and another worker can take over.</p>
+    </section>
+
+    <section>
+      <h2>Deploy lock across CI runners</h2>
+      <p>Several CI runners can all deploy production. Use <code>deploy/prod</code> as the stable job name so only one release runs at once.</p>
+    </section>
+
+    <section>
+      <h2>Cross-machine cron dedup</h2>
+      <p>Three servers all run the same hourly job for redundancy. Claim <code>cron/hourly-rollup/2026-04-01T04</code>. One wins. The others exit.</p>
+    </section>
+
+    <section>
+      <h2>Global visibility into current work</h2>
+      <p>Attach host, service, task id, claimed time, and run URL to claims. Now a status view can answer what is currently active, who owns it, and where it is running.</p>
+    </section>
+
+    <div class="pager">
+      <a href="/docs/agent-coordination.html"><span>Previous</span><strong>Agent coordination</strong></a>
+      <a href="/docs/"><span>Back to</span><strong>Docs index</strong></a>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -3,33 +3,32 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>OctoStore API Docs</title>
-  <meta name="description" content="OctoStore REST API reference — distributed locking, rate limiting, feature flags, and config storage." />
+  <title>OctoStore Docs</title>
+  <meta name="description" content="OctoStore docs: coordination guides first, interactive API reference second." />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
     body {
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
       background: #0a0a0b;
       color: #e5e5e5;
       min-height: 100vh;
     }
-
     .topbar {
       background: #111111;
       border-bottom: 1px solid rgba(255,255,255,0.08);
       padding: 0 24px;
-      height: 56px;
+      min-height: 56px;
       display: flex;
       align-items: center;
       justify-content: space-between;
       position: sticky;
       top: 0;
       z-index: 9999;
+      gap: 16px;
     }
     .topbar-brand { display: flex; align-items: center; gap: 10px; text-decoration: none; }
     .topbar-brand span { font-size: 1.1rem; font-weight: 700; color: #fff; }
-    .topbar nav { display: flex; gap: 8px; }
+    .topbar nav { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
     .topbar nav a {
       color: #a1a1aa;
       text-decoration: none;
@@ -41,10 +40,44 @@
     }
     .topbar nav a:hover { color: #fff; background: rgba(255,255,255,0.06); }
     .topbar nav a.active { color: #fff; background: rgba(99,102,241,0.15); }
-
-    /* push Scalar below our sticky topbar */
-    #scalar-container {
-      height: calc(100vh - 56px);
+    .hero {
+      max-width: 1100px; margin: 0 auto; padding: 48px 24px 28px;
+    }
+    .hero h1 { font-size: 2.55rem; line-height: 1.1; color: #fff; margin-bottom: 14px; }
+    .hero p { color: #a1a1aa; font-size: 1.08rem; max-width: 820px; }
+    .cards {
+      max-width: 1100px; margin: 0 auto; padding: 0 24px 24px;
+      display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px;
+    }
+    .card {
+      background: #111111; border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 24px;
+    }
+    .card h2 { color: #fff; font-size: 1.35rem; margin-bottom: 10px; }
+    .card p { color: #a1a1aa; margin-bottom: 16px; }
+    .card a {
+      display: inline-flex; align-items: center; gap: 8px; color: #fff; text-decoration: none;
+      background: rgba(99,102,241,0.16); padding: 10px 14px; border-radius: 10px; font-weight: 600;
+    }
+    .guides {
+      max-width: 1100px; margin: 0 auto; padding: 0 24px 28px;
+      display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px;
+    }
+    .guide {
+      background: #111111; border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 20px;
+    }
+    .guide h3 { color: #fff; font-size: 1.05rem; margin-bottom: 8px; }
+    .guide p { color: #a1a1aa; font-size: 0.95rem; margin-bottom: 14px; }
+    .guide a { color: #c4b5fd; text-decoration: none; font-weight: 600; }
+    .api-wrap { height: calc(100vh - 56px - 520px); min-height: 640px; }
+    @media (max-width: 1024px) {
+      .guides { grid-template-columns: repeat(2, 1fr); }
+      .api-wrap { height: calc(100vh - 56px - 720px); }
+    }
+    @media (max-width: 820px) {
+      .cards { grid-template-columns: 1fr; }
+      .guides { grid-template-columns: 1fr; }
+      .hero h1 { font-size: 2rem; }
+      .api-wrap { height: calc(100vh - 56px - 980px); }
     }
   </style>
 </head>
@@ -55,15 +88,66 @@
     </a>
     <nav>
       <a href="/">Home</a>
-      <a href="/status.html">Status</a>
-      <a href="/docs/" class="active">API Docs</a>
+      <a href="/docs/coordination-patterns.html">Coordination guide</a>
+      <a href="/docs/" class="active">Docs</a>
       <a href="https://github.com/aronchick/octostore-lock" target="_blank" rel="noopener">GitHub</a>
     </nav>
   </header>
 
-  <div id="scalar-container">
+  <section class="hero">
+    <h1>Docs for humans first, API docs second</h1>
+    <p>Start with the coordination guides to understand the local and multi-machine story. Then use the interactive API reference for the exact lock, lease, auth, and health endpoints.</p>
+  </section>
+
+  <section class="cards">
+    <div class="card">
+      <h2>Coordination patterns</h2>
+      <p>The core mental model: stable job names, metadata, renewals, release, and TTL-based recovery.</p>
+      <a href="/docs/coordination-patterns.html">Read the guide →</a>
+    </div>
+    <div class="card">
+      <h2>Interactive API reference</h2>
+      <p>The full OpenAPI-backed reference for auth, acquire, release, renew, lock inspection, and health endpoints.</p>
+      <a href="#api-reference">Jump to API reference ↓</a>
+    </div>
+  </section>
+
+  <section class="guides">
+    <div class="guide">
+      <h3>What is OctoStore?</h3>
+      <p>The primitive-first overview: self-hostable distributed locks and leases over HTTP.</p>
+      <a href="/docs/overview.html">Open overview →</a>
+    </div>
+    <div class="guide">
+      <h3>Local coordination</h3>
+      <p>Run it on one machine and keep scripts, workers, cron jobs, and agents from colliding.</p>
+      <a href="/docs/local-coordination.html">Open guide →</a>
+    </div>
+    <div class="guide">
+      <h3>Multi-machine coordination</h3>
+      <p>Use one shared ownership view across several servers and see what is running where.</p>
+      <a href="/docs/multi-machine-coordination.html">Open guide →</a>
+    </div>
+    <div class="guide">
+      <h3>Agent coordination</h3>
+      <p>Use OctoStore from OpenClaw or any other runtime that needs one owner per task.</p>
+      <a href="/docs/agent-coordination.html">Open guide →</a>
+    </div>
+    <div class="guide">
+      <h3>Examples</h3>
+      <p>Concrete local, CI, cron, fleet, and agent coordination examples.</p>
+      <a href="/docs/examples.html">Open examples →</a>
+    </div>
+    <div class="guide">
+      <h3>Releases</h3>
+      <p>Version notes for the docs repositioning and recent safety work.</p>
+      <a href="/docs/releases.html">Open releases →</a>
+    </div>
+  </section>
+
+  <div id="api-reference" class="api-wrap">
     <script
-      id="api-reference"
+      id="api-reference-script"
       data-url="https://api.octostore.io/openapi.yaml"
       data-configuration='{"theme":"purple","layout":"modern","defaultHttpClient":{"targetKey":"shell","clientKey":"curl"}}'
       src="https://cdn.jsdelivr.net/npm/@scalar/api-reference">

--- a/site/docs/local-coordination.html
+++ b/site/docs/local-coordination.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local coordination with OctoStore</title>
+  <meta name="description" content="Use OctoStore on one machine to coordinate local scripts, workers, cron jobs, and agents." />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#111111; --panel2:#1a1a1b; --text:#e5e5e5; --muted:#a1a1aa; --white:#fff; --accent:#6366f1; --border:rgba(255,255,255,0.08); }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif; background:var(--bg); color:var(--text); line-height:1.7; }
+    .container { max-width:980px; margin:0 auto; padding:0 24px; }
+    nav { display:flex; justify-content:space-between; align-items:center; padding:16px 0; border-bottom:1px solid var(--border); margin-bottom:48px; gap:16px; }
+    .brand { color:var(--white); text-decoration:none; font-weight:700; }
+    .nav-links { display:flex; gap:12px; flex-wrap:wrap; }
+    .nav-links a { color:var(--muted); text-decoration:none; padding:8px 14px; border-radius:8px; }
+    .nav-links a:hover, .nav-links a.active { color:var(--white); background:rgba(255,255,255,0.06); }
+    header { padding:32px 0 36px; }
+    h1 { font-size:3rem; line-height:1.08; letter-spacing:-0.03em; color:var(--white); margin-bottom:18px; }
+    .lede { font-size:1.18rem; color:var(--muted); max-width:840px; }
+    section { background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:32px; margin:24px 0; }
+    h2 { color:var(--white); font-size:1.8rem; margin-bottom:12px; }
+    p { margin:12px 0; }
+    ul, ol { margin:12px 0 12px 22px; }
+    li { margin:8px 0; }
+    pre { background:#0d1117; border:1px solid rgba(99,102,241,0.15); border-radius:12px; padding:18px; overflow-x:auto; margin-top:14px; }
+    .pager { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; margin:28px 0 56px; }
+    .pager a { display:block; background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px; color:var(--text); text-decoration:none; }
+    .pager a span { display:block; color:var(--muted); font-size:0.9rem; margin-bottom:4px; }
+    .pager a strong { color:var(--white); font-size:1.02rem; }
+    .pager a:hover { border-color:rgba(99,102,241,0.35); background:rgba(255,255,255,0.03); }
+    @media (max-width:900px){ h1{font-size:2.3rem;} .lede{font-size:1.05rem;} }
+    @media (max-width:700px){ .pager{grid-template-columns:1fr;} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a class="brand" href="/">🐙 OctoStore</a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/" class="active">Docs</a>
+        <a href="/docs/coordination-patterns.html">Coordination guide</a>
+      </div>
+    </nav>
+
+    <header>
+      <h1>Local coordination with OctoStore</h1>
+      <p class="lede">One of the simplest ways to use OctoStore is on a single machine. If multiple local processes can pick up the same task, run a local OctoStore server and have each process claim work through it.</p>
+    </header>
+
+    <section>
+      <h2>When this helps</h2>
+      <ul>
+        <li>several agents on one box</li>
+        <li>multiple cron jobs</li>
+        <li>worker pools</li>
+        <li>local daemons</li>
+        <li>dev and demo environments</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Basic pattern</h2>
+      <ol>
+        <li>start a local OctoStore server</li>
+        <li>choose one stable lock name per task</li>
+        <li>have each worker try to claim that task</li>
+        <li>renew while working</li>
+        <li>release when finished</li>
+        <li>let TTL expiry recover from crashes</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Example metadata</h2>
+      <pre><code>{
+  "owner": "thumb-worker-2",
+  "host": "media-box-01",
+  "service": "thumbnailer",
+  "task_id": "img-123",
+  "job": "generate thumbnail",
+  "claimed_at": "2026-04-01T04:02:00Z"
+}</code></pre>
+    </section>
+
+    <section>
+      <h2>Why local mode is attractive</h2>
+      <ul>
+        <li>dead simple</li>
+        <li>self-hosted</li>
+        <li>private</li>
+        <li>low latency</li>
+        <li>easy to debug</li>
+        <li>no external dependency</li>
+      </ul>
+    </section>
+
+    <div class="pager">
+      <a href="/docs/coordination-patterns.html"><span>Previous</span><strong>Coordination patterns</strong></a>
+      <a href="/docs/multi-machine-coordination.html"><span>Next</span><strong>Multi-machine coordination</strong></a>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/docs/multi-machine-coordination.html
+++ b/site/docs/multi-machine-coordination.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Multi-machine coordination with OctoStore</title>
+  <meta name="description" content="Use one OctoStore deployment to coordinate workers across many machines and see what is running where." />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#111111; --panel2:#1a1a1b; --text:#e5e5e5; --muted:#a1a1aa; --white:#fff; --accent:#6366f1; --border:rgba(255,255,255,0.08); }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif; background:var(--bg); color:var(--text); line-height:1.7; }
+    .container { max-width:980px; margin:0 auto; padding:0 24px; }
+    nav { display:flex; justify-content:space-between; align-items:center; padding:16px 0; border-bottom:1px solid var(--border); margin-bottom:48px; gap:16px; }
+    .brand { color:var(--white); text-decoration:none; font-weight:700; }
+    .nav-links { display:flex; gap:12px; flex-wrap:wrap; }
+    .nav-links a { color:var(--muted); text-decoration:none; padding:8px 14px; border-radius:8px; }
+    .nav-links a:hover, .nav-links a.active { color:var(--white); background:rgba(255,255,255,0.06); }
+    header { padding:32px 0 36px; }
+    h1 { font-size:3rem; line-height:1.08; letter-spacing:-0.03em; color:var(--white); margin-bottom:18px; }
+    .lede { font-size:1.18rem; color:var(--muted); max-width:840px; }
+    section { background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:32px; margin:24px 0; }
+    h2 { color:var(--white); font-size:1.8rem; margin-bottom:12px; }
+    p { margin:12px 0; }
+    ul, ol { margin:12px 0 12px 22px; }
+    li { margin:8px 0; }
+    pre { background:#0d1117; border:1px solid rgba(99,102,241,0.15); border-radius:12px; padding:18px; overflow-x:auto; margin-top:14px; }
+    .pager { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; margin:28px 0 56px; }
+    .pager a { display:block; background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px; color:var(--text); text-decoration:none; }
+    .pager a span { display:block; color:var(--muted); font-size:0.9rem; margin-bottom:4px; }
+    .pager a strong { color:var(--white); font-size:1.02rem; }
+    .pager a:hover { border-color:rgba(99,102,241,0.35); background:rgba(255,255,255,0.03); }
+    @media (max-width:900px){ h1{font-size:2.3rem;} .lede{font-size:1.05rem;} }
+    @media (max-width:700px){ .pager{grid-template-columns:1fr;} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a class="brand" href="/">🐙 OctoStore</a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/" class="active">Docs</a>
+        <a href="/docs/coordination-patterns.html">Coordination guide</a>
+      </div>
+    </nav>
+
+    <header>
+      <h1>Multi-machine coordination with OctoStore</h1>
+      <p class="lede">A shared OctoStore deployment lets workers across many servers coordinate through one simple HTTP API and gives them a shared view of who owns what.</p>
+    </header>
+
+    <section>
+      <h2>The problem</h2>
+      <ul>
+        <li>duplicate work across servers</li>
+        <li>no shared view of ownership</li>
+        <li>hard-to-debug collisions</li>
+        <li>orphaned work after machine failure</li>
+        <li>unclear answers to “what is running where?”</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>The pattern</h2>
+      <p>Every worker, on every machine:</p>
+      <ul>
+        <li>claims work using the same stable job name</li>
+        <li>publishes structured metadata</li>
+        <li>renews while healthy</li>
+        <li>releases on completion</li>
+        <li>relies on TTL expiry for crash recovery</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Example metadata</h2>
+      <pre><code>{
+  "owner": "research-worker",
+  "host": "server-c",
+  "service": "market-intel",
+  "task_id": "acct-acme",
+  "job": "refresh account summary",
+  "claimed_at": "2026-04-01T04:05:00Z",
+  "run_id": "run-9921",
+  "run_url": "https://ops.example/runs/9921",
+  "note": "phase 2 enrichment"
+}</code></pre>
+      <p>Now every machine can answer who owns a job, which host is running it, and where to inspect the run.</p>
+    </section>
+
+    <section>
+      <h2>Good fits</h2>
+      <ul>
+        <li>shared job processing</li>
+        <li>deploy serialization</li>
+        <li>cross-machine cron dedup</li>
+        <li>agent fleets spread across servers</li>
+      </ul>
+    </section>
+
+    <div class="pager">
+      <a href="/docs/local-coordination.html"><span>Previous</span><strong>Local coordination</strong></a>
+      <a href="/docs/agent-coordination.html"><span>Next</span><strong>Agent coordination</strong></a>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/docs/overview.html
+++ b/site/docs/overview.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>What is OctoStore?</title>
+  <meta name="description" content="OctoStore is a self-hostable distributed lock and lease service over HTTP for local and multi-machine coordination." />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#111111; --panel2:#1a1a1b; --text:#e5e5e5; --muted:#a1a1aa; --white:#fff; --accent:#6366f1; --border:rgba(255,255,255,0.08); }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif; background:var(--bg); color:var(--text); line-height:1.7; }
+    .container { max-width:980px; margin:0 auto; padding:0 24px; }
+    nav { display:flex; justify-content:space-between; align-items:center; padding:16px 0; border-bottom:1px solid var(--border); margin-bottom:48px; gap:16px; }
+    .brand { color:var(--white); text-decoration:none; font-weight:700; }
+    .nav-links { display:flex; gap:12px; flex-wrap:wrap; }
+    .nav-links a { color:var(--muted); text-decoration:none; padding:8px 14px; border-radius:8px; }
+    .nav-links a:hover, .nav-links a.active { color:var(--white); background:rgba(255,255,255,0.06); }
+    header { padding:32px 0 36px; }
+    h1 { font-size:3rem; line-height:1.08; letter-spacing:-0.03em; color:var(--white); margin-bottom:18px; }
+    .lede { font-size:1.18rem; color:var(--muted); max-width:840px; }
+    section { background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:32px; margin:24px 0; }
+    h2 { color:var(--white); font-size:1.8rem; margin-bottom:12px; }
+    p { margin:12px 0; }
+    ul, ol { margin:12px 0 12px 22px; }
+    li { margin:8px 0; }
+    pre { background:#0d1117; border:1px solid rgba(99,102,241,0.15); border-radius:12px; padding:18px; overflow-x:auto; margin-top:14px; }
+    .quote { font-size:1.18rem; color:var(--white); border-left:3px solid var(--accent); padding-left:16px; }
+    .pager { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; margin:28px 0 56px; }
+    .pager a { display:block; background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px; color:var(--text); text-decoration:none; }
+    .pager a span { display:block; color:var(--muted); font-size:0.9rem; margin-bottom:4px; }
+    .pager a strong { color:var(--white); font-size:1.02rem; }
+    .pager a:hover { border-color:rgba(99,102,241,0.35); background:rgba(255,255,255,0.03); }
+    @media (max-width:900px){ h1{font-size:2.3rem;} .lede{font-size:1.05rem;} }
+    @media (max-width:700px){ .pager{grid-template-columns:1fr;} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a class="brand" href="/">🐙 OctoStore</a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/" class="active">Docs</a>
+        <a href="/docs/coordination-patterns.html">Coordination guide</a>
+      </div>
+    </nav>
+
+    <header>
+      <h1>What is OctoStore?</h1>
+      <p class="lede">OctoStore is a self-hostable distributed lock and lease service over HTTP. Use it locally or across many machines to coordinate work with visible ownership and automatic recovery.</p>
+    </header>
+
+    <section>
+      <h2>Core idea</h2>
+      <p>When several workers can all see the same task, one of them should claim it and the others should back off.</p>
+      <p>OctoStore provides the primitive for that:</p>
+      <ul>
+        <li>create a lock or lease for a stable job name</li>
+        <li>renew it while the owner is alive</li>
+        <li>release it when done</li>
+        <li>let it expire automatically if the owner dies</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Why this matters</h2>
+      <p>Without a shared lock or lease layer, distributed systems drift into the same failures:</p>
+      <ul>
+        <li>duplicate work</li>
+        <li>invisible ownership</li>
+        <li>blind retries</li>
+        <li>stuck work after crashes</li>
+        <li>ad hoc coordination logic scattered across services</li>
+      </ul>
+      <p>OctoStore gives you one clean coordination primitive instead.</p>
+    </section>
+
+    <section>
+      <h2>Local or global</h2>
+      <p>You can use OctoStore in two natural modes.</p>
+      <h3 style="color:#fff; margin-top:18px;">Local coordination</h3>
+      <p>Run it on one machine and let local scripts, cron jobs, workers, services, or agents coordinate through it.</p>
+      <h3 style="color:#fff; margin-top:18px;">Multi-machine coordination</h3>
+      <p>Run one shared OctoStore deployment and let workers across many machines coordinate through the same API.</p>
+    </section>
+
+    <section>
+      <h2>What it is not</h2>
+      <p>OctoStore is not trying to be:</p>
+      <ul>
+        <li>a workflow engine</li>
+        <li>a queue</li>
+        <li>a scheduler</li>
+        <li>a giant orchestration control plane</li>
+      </ul>
+      <p class="quote">It is the coordination primitive underneath those higher-level patterns.</p>
+    </section>
+
+    <div class="pager">
+      <a href="/docs/coordination-patterns.html"><span>Next</span><strong>Coordination patterns</strong></a>
+      <a href="/docs/local-coordination.html"><span>Then</span><strong>Local coordination</strong></a>
+    </div>
+  </div>
+</body>
+</html>

--- a/site/docs/releases.html
+++ b/site/docs/releases.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OctoStore releases</title>
+  <meta name="description" content="Release notes and changelog highlights for OctoStore." />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#111111; --text:#e5e5e5; --muted:#a1a1aa; --white:#fff; --accent:#6366f1; --border:rgba(255,255,255,0.08); }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif; background:var(--bg); color:var(--text); line-height:1.7; }
+    .container { max-width:980px; margin:0 auto; padding:0 24px; }
+    nav { display:flex; justify-content:space-between; align-items:center; padding:16px 0; border-bottom:1px solid var(--border); margin-bottom:48px; gap:16px; }
+    .brand { color:var(--white); text-decoration:none; font-weight:700; }
+    .nav-links { display:flex; gap:12px; flex-wrap:wrap; }
+    .nav-links a { color:var(--muted); text-decoration:none; padding:8px 14px; border-radius:8px; }
+    .nav-links a:hover, .nav-links a.active { color:var(--white); background:rgba(255,255,255,0.06); }
+    header { padding:32px 0 36px; }
+    h1 { font-size:3rem; line-height:1.08; letter-spacing:-0.03em; color:var(--white); margin-bottom:18px; }
+    .lede { font-size:1.18rem; color:var(--muted); max-width:840px; }
+    section { background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:32px; margin:24px 0; }
+    h2 { color:var(--white); font-size:1.8rem; margin-bottom:12px; }
+    p { margin:12px 0; }
+    ul { margin:12px 0 12px 22px; }
+    li { margin:8px 0; }
+    .version { display:inline-block; padding:8px 12px; border-radius:999px; background:rgba(99,102,241,0.15); color:#c4b5fd; font-weight:700; margin-bottom:14px; }
+    @media (max-width:900px){ h1{font-size:2.3rem;} .lede{font-size:1.05rem;} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <nav>
+      <a class="brand" href="/">🐙 OctoStore</a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/" class="active">Docs</a>
+        <a href="/docs/coordination-patterns.html">Coordination guide</a>
+      </div>
+    </nav>
+
+    <header>
+      <h1>OctoStore releases</h1>
+      <p class="lede">Version notes for product positioning, docs, and API safety features.</p>
+    </header>
+
+    <section>
+      <div class="version">v0.10.0</div>
+      <h2>Coordination-first positioning</h2>
+      <p>This release reframes OctoStore around the real primitive: self-hostable distributed locks and leases over HTTP for local and multi-machine coordination.</p>
+      <ul>
+        <li>homepage updated to lead with coordination, not just agents</li>
+        <li>docs index reorganized so the conceptual guides come before the API reference</li>
+        <li>new narrative docs added for overview, coordination patterns, local coordination, multi-machine coordination, agent coordination, and examples</li>
+        <li>README rewritten to match the broader product story</li>
+      </ul>
+    </section>
+
+    <section>
+      <div class="version">v0.9.x</div>
+      <h2>Safety and durability groundwork</h2>
+      <ul>
+        <li>namespace-scoped lock access enforcement</li>
+        <li>WAL-backed lock recovery and health storage telemetry</li>
+        <li>remaining namespace test cleanup</li>
+      </ul>
+    </section>
+  </div>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OctoStore — Distributed locking as a service</title>
+    <title>OctoStore — Self-hostable coordination over HTTP</title>
+    <meta name="description" content="OctoStore is a self-hostable distributed lock and lease service over HTTP. Use it locally or across many machines to coordinate work with visible ownership and automatic recovery.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-dark.min.css">
     <style>
         :root {
             --bg-primary: #0a0a0b;
@@ -19,27 +19,11 @@
             --accent: #6366f1;
             --accent-hover: #5b5ce8;
             --border: rgba(255, 255, 255, 0.08);
-            --border-hover: rgba(255, 255, 255, 0.12);
-            --gradient: linear-gradient(135deg, rgba(99,102,241,0.08) 0%, rgba(168,85,247,0.06) 100%);
-            --c-indigo: #6366f1;
-            --c-violet: #a855f7;
-            --c-sky:    #38bdf8;
-            --c-emerald:#10b981;
-            --c-amber:  #f59e0b;
-            --c-rose:   #f43f5e;
+            --border-hover: rgba(255, 255, 255, 0.14);
             --shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
             --shadow-lg: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
         }
-
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        a { color: #a1a1aa; text-decoration: none; }
-        a:hover { color: var(--text-primary, #ffffff); }
-
+        * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
             background: var(--bg-primary);
@@ -47,657 +31,275 @@
             line-height: 1.6;
             overflow-x: hidden;
         }
-
-        /* Background glow */
         body::before {
             content: '';
             position: fixed;
-            top: 0; left: 50%;
-            transform: translateX(-50%);
-            width: 900px; height: 600px;
-            background: radial-gradient(ellipse at 40% 30%, rgba(99,102,241,0.12) 0%, transparent 60%),
+            top: 0; left: 50%; transform: translateX(-50%);
+            width: 920px; height: 620px;
+            background: radial-gradient(ellipse at 40% 30%, rgba(99,102,241,0.14) 0%, transparent 60%),
                         radial-gradient(ellipse at 70% 60%, rgba(168,85,247,0.08) 0%, transparent 55%);
             z-index: -1;
             pointer-events: none;
         }
-
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 0 24px;
+        a { color: #a1a1aa; text-decoration: none; }
+        a:hover { color: var(--text-primary); }
+        .container { max-width: 1180px; margin: 0 auto; padding: 0 24px; }
+        nav {
+            display: flex; justify-content: space-between; align-items: center;
+            padding: 16px 0; border-bottom: 1px solid var(--border); margin-bottom: 40px;
         }
-
-        /* Header */
-        header {
-            padding: 80px 0 120px;
-            text-align: center;
-            position: relative;
+        .brand { display: flex; align-items: center; gap: 8px; color: #fff; font-weight: 600; font-size: 1.25rem; }
+        .nav-links { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
+        .nav-links a { color: #a1a1aa; font-weight: 500; padding: 8px 14px; border-radius: 8px; transition: all 0.2s; }
+        .nav-links a:hover, .nav-links a.active { color: #e5e5e5; background: rgba(255,255,255,0.05); }
+        header { padding: 56px 0 88px; text-align: center; }
+        .hero-icon { font-size: 5rem; margin-bottom: 18px; display: block; }
+        .eyebrow {
+            display: inline-block; padding: 8px 14px; border: 1px solid rgba(99,102,241,0.25);
+            border-radius: 999px; background: rgba(99,102,241,0.08); color: #c4b5fd; font-weight: 600; margin-bottom: 24px;
         }
-
-        .hero-content {
-            animation: fadeInUp 0.8s ease-out;
-        }
-
-        @keyframes fadeInUp {
-            from {
-                opacity: 0;
-                transform: translateY(30px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        .hero-logo {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin-bottom: 32px;
-            gap: 20px;
-        }
-
-        .hero-icon {
-            width: 120px;
-            height: 120px;
-            filter: drop-shadow(0 0 30px rgba(99, 102, 241, 0.4));
-        }
-
-        .hero-headline {
-            font-size: 5rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            letter-spacing: -0.03em;
-            line-height: 1.05;
-            margin: 0 0 24px;
-        }
-
-        .hero-headline .highlight {
-            background: linear-gradient(135deg, #6366f1 0%, #a855f7 50%, #6366f1 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-
         h1 {
-            font-size: 4.5rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            background: linear-gradient(135deg, #ffffff 0%, #e5e5e5 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            margin: 0;
-            display: none;
+            font-size: 4.2rem; font-weight: 700; color: var(--text-primary);
+            letter-spacing: -0.04em; line-height: 1.02; max-width: 980px; margin: 0 auto 24px;
         }
-
         .tagline {
-            font-size: 1.25rem;
-            color: var(--text-muted);
-            margin: 0 0 48px;
-            font-weight: 400;
-            max-width: 480px;
-            margin-left: auto;
-            margin-right: auto;
+            font-size: 1.26rem; color: var(--text-muted); max-width: 900px; margin: 0 auto 36px;
         }
-
-        .cta-buttons {
-            display: flex;
-            gap: 24px;
-            justify-content: center;
-            align-items: center;
-            flex-wrap: wrap;
+        .cta-buttons { display: flex; gap: 18px; justify-content: center; flex-wrap: wrap; }
+        .primary-btn, .secondary-btn {
+            display: inline-flex; align-items: center; gap: 10px; padding: 16px 28px; border-radius: 12px;
+            font-weight: 600; transition: all 0.2s ease; box-shadow: var(--shadow);
         }
-
-        .github-auth-btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 12px;
-            background: #24292f;
-            border: 1px solid #30363d;
-            color: #ffffff;
-            text-decoration: none;
-            padding: 16px 32px;
-            border-radius: 12px;
-            font-weight: 600;
-            font-size: 1.1rem;
-            transition: all 0.2s ease;
-            box-shadow: var(--shadow);
-            position: relative;
-            overflow: hidden;
+        .primary-btn {
+            background: var(--accent); color: #fff; border: 1px solid rgba(99,102,241,0.55);
         }
-
-        .github-auth-btn::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, transparent 50%);
-            opacity: 0;
-            transition: opacity 0.2s ease;
-        }
-
-        .github-auth-btn:hover::before {
-            opacity: 1;
-        }
-
-        .github-auth-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: var(--shadow-lg);
-            border-color: #4c5861;
-        }
-
-        .github-icon {
-            width: 24px;
-            height: 24px;
-            fill: currentColor;
-        }
-
+        .primary-btn:hover { background: var(--accent-hover); transform: translateY(-2px); box-shadow: var(--shadow-lg); }
         .secondary-btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            background: transparent;
-            border: 1px solid var(--border);
-            color: var(--text-secondary);
-            text-decoration: none;
-            padding: 16px 32px;
-            border-radius: 12px;
-            font-weight: 500;
-            font-size: 1.1rem;
-            transition: all 0.2s ease;
-            backdrop-filter: blur(10px);
+            background: transparent; color: var(--text-secondary); border: 1px solid var(--border);
         }
-
-        .secondary-btn:hover {
-            border-color: var(--border-hover);
-            background: rgba(255, 255, 255, 0.05);
-            transform: translateY(-1px);
+        .secondary-btn:hover { background: rgba(255,255,255,0.05); border-color: var(--border-hover); transform: translateY(-1px); }
+        .statement {
+            margin: 44px auto 0; max-width: 940px; background: rgba(99,102,241,0.06);
+            border: 1px solid rgba(99,102,241,0.2); border-radius: 16px; padding: 20px 24px; color: #e9e7ff;
         }
-
-        /* Disclaimer */
-        .disclaimer {
-            background: rgba(99,102,241,0.06);
-            border: 1px solid rgba(99,102,241,0.2);
-            border-radius: 16px;
-            padding: 24px 32px;
-            margin: 80px 0;
-            text-align: center;
-            animation: fadeIn 0.8s ease-out 0.3s both;
-        }
-
-        @keyframes fadeIn {
-            from { opacity: 0; }
-            to { opacity: 1; }
-        }
-
-        .disclaimer p {
-            color: var(--text-muted);
-            font-size: 1.2rem;
-            font-weight: 500;
-        }
-
-        /* Sections */
-        section {
-            margin: 100px 0;
-            animation: fadeIn 0.8s ease-out both;
-        }
-
-        section:nth-child(even) {
-            animation-delay: 0.1s;
-        }
-
-        section:nth-child(odd) {
-            animation-delay: 0.2s;
-        }
-
-        h2 {
-            font-size: 2.5rem;
-            margin-bottom: 24px;
-            color: var(--text-primary);
-            font-weight: 700;
-            text-align: center;
-        }
-
+        section { margin: 82px 0; }
+        h2 { font-size: 2.35rem; margin-bottom: 18px; color: #fff; text-align: center; }
         .section-subtitle {
-            text-align: center;
-            font-size: 1.2rem;
-            color: var(--text-muted);
-            margin-bottom: 60px;
-            max-width: 600px;
-            margin-left: auto;
-            margin-right: auto;
+            text-align: center; font-size: 1.14rem; color: var(--text-muted); max-width: 800px; margin: 0 auto 42px;
         }
-
-        /* Feature grid */
-        .features-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 24px;
-            margin: 60px 0;
+        .grid { display: grid; gap: 24px; }
+        .problem-grid, .feature-grid, .modes-grid, .guides-grid { grid-template-columns: repeat(3, 1fr); }
+        .card {
+            background: var(--bg-secondary); border: 1px solid var(--border); border-radius: 16px; padding: 28px;
+            box-shadow: var(--shadow); transition: transform 0.2s ease, border-color 0.2s ease;
         }
-
-        @media (max-width: 900px) {
-            .features-grid { grid-template-columns: repeat(2, 1fr) !important; }
+        .card:hover { transform: translateY(-3px); border-color: rgba(99,102,241,0.35); }
+        .card h3 { color: #fff; font-size: 1.3rem; margin-bottom: 12px; }
+        .card p { color: var(--text-muted); }
+        .kicker { font-size: 1.8rem; margin-bottom: 14px; display: inline-block; }
+        .example {
+            background: linear-gradient(180deg, rgba(99,102,241,0.08), rgba(17,17,17,0.95));
+            border: 1px solid rgba(99,102,241,0.18); border-radius: 20px; padding: 36px;
         }
-
-        .feature-card {
-            background: var(--bg-secondary);
-            border: 1px solid var(--border);
-            border-top: 2px solid var(--card-color, var(--accent));
-            border-radius: 12px;
-            padding: 28px;
-            transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-            position: relative;
+        .example-quote {
+            font-size: 1.5rem; line-height: 1.5; color: #fff; font-weight: 600; margin-bottom: 24px;
         }
-
-        .feature-card:hover {
-            transform: translateY(-3px);
-            border-color: var(--card-color, var(--accent));
-            box-shadow: 0 0 0 1px var(--card-color, var(--accent)), var(--shadow);
+        .example ol { margin-left: 22px; color: var(--text-secondary); }
+        .example li { margin: 10px 0; }
+        .footer-cta {
+            text-align: center; padding: 44px 28px; border: 1px solid var(--border); border-radius: 20px; background: var(--bg-secondary);
         }
-
-        .feature-icon {
-            display: inline-flex; align-items: center; justify-content: center;
-            width: 44px; height: 44px; border-radius: 10px;
-            background: color-mix(in srgb, var(--card-color, var(--accent)) 15%, transparent);
-            font-size: 1.4rem; margin-bottom: 16px;
+        footer { text-align: center; margin: 90px 0 60px; padding-top: 32px; border-top: 1px solid var(--border); color: var(--text-muted); }
+        @media (max-width: 920px) {
+            h1 { font-size: 3rem; }
+            .problem-grid, .feature-grid, .modes-grid, .guides-grid { grid-template-columns: 1fr; }
         }
-
-
-
-        .feature-title {
-            font-size: 1.5rem;
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 16px;
-        }
-
-        .feature-description {
-            color: var(--text-muted);
-            line-height: 1.6;
-        }
-
-        /* API section */
-        .api-section {
-            background: var(--bg-secondary);
-            border: 1px solid var(--border);
-            border-radius: 20px;
-            padding: 48px;
-            margin: 60px 0;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .api-section::before {
-            content: '';
-            position: absolute;
-            inset: 0; border-radius: 20px;
-            background: linear-gradient(135deg, rgba(99,102,241,0.04) 0%, transparent 60%);
-            pointer-events: none;
-        }
-
-        .api-endpoints {
-            display: grid;
-            gap: 32px;
-            margin-top: 40px;
-        }
-
-        .endpoint-group {
-            background: var(--bg-primary);
-            border: 1px solid var(--border);
-            border-radius: 12px;
-            padding: 24px;
-        }
-
-        .endpoint-title {
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 16px;
-            font-size: 1.3rem;
-        }
-
-        .code-block {
-            background: #0d1117;
-            border: 1px solid rgba(99, 102, 241, 0.15);
-            border-radius: 8px;
-            padding: 24px;
-            overflow-x: auto;
-            font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
-            font-size: 14px;
-            line-height: 1.7;
-        }
-
-        .code-block code {
-            color: #e6edf3;
-        }
-
-        .code-block .cmd { color: #79c0ff; }
-        .code-block .flag { color: #d2a8ff; }
-        .code-block .url { color: #a5d6ff; }
-        .code-block .header { color: #7ee787; }
-        .code-block .string { color: #ffa657; }
-        .code-block .comment { color: #8b949e; font-style: italic; }
-
-        /* Constraints */
-        .constraints {
-            background: var(--bg-secondary);
-            border-left: 4px solid var(--accent);
-            border-radius: 12px;
-            padding: 32px;
-            margin: 40px 0;
-        }
-
-        .constraints h3 {
-            color: var(--text-primary);
-            margin-bottom: 20px;
-            font-size: 1.4rem;
-        }
-
-        .constraints ul {
-            margin-left: 20px;
-        }
-
-        .constraints li {
-            margin-bottom: 12px;
-            color: var(--text-muted);
-        }
-
-        /* Footer */
-        footer {
-            text-align: center;
-            margin: 120px 0 80px;
-            padding: 40px 0;
-            border-top: 1px solid var(--border);
-            color: var(--text-muted);
-        }
-
-        footer p {
-            font-size: 1.1rem;
-        }
-
-        /* Responsive */
-        @media (max-width: 768px) {
-            .container {
-                padding: 0 16px;
-            }
-
-            h1 {
-                font-size: 3rem;
-            }
-
-            .hero-headline {
-                font-size: 3.2rem;
-            }
-
-            .hero-icon {
-                width: 90px;
-                height: 90px;
-            }
-
-            .tagline {
-                font-size: 1.1rem;
-            }
-
-            .cta-buttons {
-                flex-direction: column;
-                align-items: stretch;
-            }
-
-            .github-auth-btn,
-            .secondary-btn {
-                justify-content: center;
-            }
-
-            .features-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .api-section {
-                padding: 32px 24px;
-            }
-
-            .code-block {
-                font-size: 12px;
-            }
-        }
-
-        @media (max-width: 480px) {
-            header {
-                padding: 60px 0 80px;
-            }
-
-            h1 {
-                font-size: 2.5rem;
-            }
-
-            .hero-headline {
-                font-size: 2.5rem;
-            }
-
-            .hero-icon {
-                width: 70px;
-                height: 70px;
-            }
+        @media (max-width: 640px) {
+            .container { padding: 0 16px; }
+            nav { flex-direction: column; gap: 14px; }
+            .nav-links { gap: 10px; justify-content: center; }
+            h1 { font-size: 2.35rem; }
+            .tagline { font-size: 1.06rem; }
+            .cta-buttons { flex-direction: column; }
+            .primary-btn, .secondary-btn { justify-content: center; }
+            .example-quote { font-size: 1.22rem; }
         }
     </style>
 </head>
 <body>
     <div class="container">
-        <nav style="display: flex; justify-content: space-between; align-items: center; padding: 16px 0; border-bottom: 1px solid rgba(255, 255, 255, 0.08); margin-bottom: 40px;">
-            <a href="/" style="display: flex; align-items: center; gap: 8px; text-decoration: none;">
-                <span style="font-size: 1.5rem;">🐙</span>
-                <span style="font-size: 1.25rem; font-weight: 600; color: #ffffff;">OctoStore</span>
-            </a>
-            <div style="display: flex; gap: 24px; align-items: center;">
-                <a href="/" style="color: #e5e5e5; text-decoration: none; font-weight: 500; padding: 8px 16px; border-radius: 6px; transition: all 0.2s;">Home</a>
-                <a href="/dashboard.html" style="color: #a1a1aa; text-decoration: none; font-weight: 500; padding: 8px 16px; border-radius: 6px; transition: all 0.2s;">Dashboard</a>
-                <a href="https://api.octostore.io/docs" style="color: #a1a1aa; text-decoration: none; font-weight: 500; padding: 8px 16px; border-radius: 6px; transition: all 0.2s;">API Docs</a>
+        <nav>
+            <a href="/" class="brand"><span>🐙</span><span>OctoStore</span></a>
+            <div class="nav-links">
+                <a href="/" class="active">Home</a>
+                <a href="/docs/coordination-patterns.html">Coordination guide</a>
+                <a href="/docs/">Docs</a>
+                <a href="/dashboard.html">Dashboard</a>
             </div>
         </nav>
+
         <header>
-            <div class="hero-content">
-                <svg class="hero-icon" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-                  <!-- Octopus body -->
-                  <ellipse cx="100" cy="72" rx="58" ry="52" fill="url(#octoGrad)"/>
-                  <!-- Eyes -->
-                  <ellipse cx="78" cy="64" rx="14" ry="16" fill="#fff"/>
-                  <ellipse cx="122" cy="64" rx="14" ry="16" fill="#fff"/>
-                  <circle cx="82" cy="66" r="7" fill="#1a1a2e"/>
-                  <circle cx="118" cy="66" r="7" fill="#1a1a2e"/>
-                  <circle cx="84" cy="63" r="2.5" fill="#fff"/>
-                  <circle cx="120" cy="63" r="2.5" fill="#fff"/>
-                  <!-- Smile -->
-                  <path d="M88 82 Q100 92 112 82" stroke="#1a1a2e" stroke-width="2.5" fill="none" stroke-linecap="round"/>
-                  <!-- Tentacles -->
-                  <path d="M52 105 Q30 130 38 160 Q42 168 48 158 Q52 140 60 120" fill="url(#octoGrad)" opacity="0.9">
-                    <animateTransform attributeName="transform" type="rotate" values="-2 52 105;2 52 105;-2 52 105" dur="3s" repeatCount="indefinite"/>
-                  </path>
-                  <path d="M65 112 Q50 145 55 172 Q58 180 64 170 Q68 148 72 125" fill="url(#octoGrad)" opacity="0.85">
-                    <animateTransform attributeName="transform" type="rotate" values="1 65 112;-2 65 112;1 65 112" dur="3.5s" repeatCount="indefinite"/>
-                  </path>
-                  <path d="M82 118 Q75 155 80 178 Q84 186 88 176 Q88 152 86 128" fill="url(#octoGrad)" opacity="0.9">
-                    <animateTransform attributeName="transform" type="rotate" values="-1 82 118;1 82 118;-1 82 118" dur="4s" repeatCount="indefinite"/>
-                  </path>
-                  <path d="M100 120 Q100 158 102 180 Q104 188 108 178 Q106 155 104 128" fill="url(#octoGrad)" opacity="0.85">
-                    <animateTransform attributeName="transform" type="rotate" values="0.5 100 120;-0.5 100 120;0.5 100 120" dur="3.2s" repeatCount="indefinite"/>
-                  </path>
-                  <path d="M118 118 Q125 155 120 178 Q116 186 112 176 Q112 152 114 128" fill="url(#octoGrad)" opacity="0.9">
-                    <animateTransform attributeName="transform" type="rotate" values="1 118 118;-1 118 118;1 118 118" dur="3.8s" repeatCount="indefinite"/>
-                  </path>
-                  <path d="M135 112 Q150 145 145 172 Q142 180 136 170 Q132 148 128 125" fill="url(#octoGrad)" opacity="0.85">
-                    <animateTransform attributeName="transform" type="rotate" values="-1 135 112;2 135 112;-1 135 112" dur="3.3s" repeatCount="indefinite"/>
-                  </path>
-                  <path d="M148 105 Q170 130 162 160 Q158 168 152 158 Q148 140 140 120" fill="url(#octoGrad)" opacity="0.9">
-                    <animateTransform attributeName="transform" type="rotate" values="2 148 105;-2 148 105;2 148 105" dur="3.6s" repeatCount="indefinite"/>
-                  </path>
-                  <!-- Lock held in front tentacle -->
-                  <g transform="translate(148, 148) scale(0.7)">
-                    <rect x="0" y="12" width="24" height="20" rx="3" fill="#fbbf24" stroke="#d97706" stroke-width="1.5"/>
-                    <path d="M6 12 V8 Q6 0 12 0 Q18 0 18 8 V12" fill="none" stroke="#d97706" stroke-width="2.5" stroke-linecap="round"/>
-                    <circle cx="12" cy="22" r="3" fill="#92400e"/>
-                  </g>
-                  <defs>
-                    <linearGradient id="octoGrad" x1="0" y1="0" x2="1" y2="1">
-                      <stop offset="0%" stop-color="#6366f1"/>
-                      <stop offset="100%" stop-color="#a855f7"/>
-                    </linearGradient>
-                  </defs>
-                </svg>
-                <div class="hero-headline">Lock. <span class="highlight">Ship.</span></div>
-                <p class="tagline">Distributed locking with fencing tokens. One binary, simple HTTP API, free to use.</p>
-                <div class="cta-buttons">
-                    <a id="auth-btn" href="https://api.octostore.io/auth/github" class="github-auth-btn">
-                        <svg class="github-icon" viewBox="0 0 16 16">
-                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                        </svg>
-                        Sign in with GitHub
-                    </a>
-                    <a href="https://api.octostore.io/docs" class="secondary-btn">
-                        View API Docs
-                        <span>→</span>
-                    </a>
-                </div>
+            <span class="eyebrow">Self-hostable coordination over HTTP</span>
+            <span class="hero-icon">🐙</span>
+            <h1>Distributed locks and leases for local and multi-machine coordination</h1>
+            <p class="tagline">OctoStore is a self-hostable distributed lock and lease service over HTTP. Use it on one machine or across many machines to coordinate work with visible ownership and automatic recovery.</p>
+            <div class="cta-buttons">
+                <a href="/docs/coordination-patterns.html" class="primary-btn">See coordination patterns →</a>
+                <a href="/docs/" class="secondary-btn">Read the docs</a>
             </div>
+            <div class="statement"><strong>Primitive first:</strong> OctoStore is the lock and lease layer. On top of it, you can build simple coordination for scripts, workers, services, CI jobs, and agents.</div>
         </header>
 
-        <div class="disclaimer">
-            <p>⚠️ Alpha software. No SLA, no business model. Just an octopus holding your locks. 🐙</p>
-        </div>
-
         <section>
-            <h2>What it does</h2>
-            <p class="section-subtitle">Distributed locking via a simple HTTP API. Sign up with GitHub, get a bearer token, start locking.</p>
-            
-            <div class="features-grid">
-                <div class="feature-card" style="--card-color: var(--c-indigo)">
-                    <span class="feature-icon">🔒</span>
-                    <h3 class="feature-title">Distributed Locking</h3>
-                    <p class="feature-description">Acquire exclusive locks with automatic expiration and monotonic fencing tokens for safe distributed coordination.</p>
+            <h2>Why it exists</h2>
+            <p class="section-subtitle">When multiple workers can all see the same task, one of them should claim it and the others should back off.</p>
+            <div class="grid problem-grid">
+                <div class="card">
+                    <div class="kicker">⚠️</div>
+                    <h3>Duplicate work</h3>
+                    <p>Several workers, services, or agents all pick up the same task because they can all see the same backlog.</p>
                 </div>
-                <div class="feature-card" style="--card-color: var(--c-violet)">
-                    <span class="feature-icon">🛡️</span>
-                    <h3 class="feature-title">Fencing Tokens</h3>
-                    <p class="feature-description">Every acquire returns a strictly increasing token. Use it to prevent stale holders from corrupting shared state.</p>
+                <div class="card">
+                    <div class="kicker">👀</div>
+                    <h3>Invisible ownership</h3>
+                    <p>Nobody can tell who owns a job, where it is running, or what it is doing right now.</p>
                 </div>
-                <div class="feature-card" style="--card-color: var(--c-sky)">
-                    <span class="feature-icon">⚡</span>
-                    <h3 class="feature-title">Simple HTTP API</h3>
-                    <p class="feature-description">Pure REST with JSON responses. No client libraries needed — curl works fine from any language.</p>
-                </div>
-                <div class="feature-card" style="--card-color: var(--c-emerald)">
-                    <span class="feature-icon">📦</span>
-                    <h3 class="feature-title">One Binary, Zero Deps</h3>
-                    <p class="feature-description">No etcd, no ZooKeeper, no Consul. Self-host with a single binary and a SQLite file. Done in 60 seconds.</p>
-                </div>
-                <div class="feature-card" style="--card-color: var(--c-amber)">
-                    <span class="feature-icon">⏱️</span>
-                    <h3 class="feature-title">Auto-Expiry</h3>
-                    <p class="feature-description">Locks expire automatically via configurable TTLs. Crashed holders never block your system forever.</p>
-                </div>
-                <div class="feature-card" style="--card-color: var(--c-rose)">
-                    <span class="feature-icon">🏠</span>
-                    <h3 class="feature-title">Self-Hostable</h3>
-                    <p class="feature-description">Use octostore.io or run your own. Optional GitHub OAuth — or bring static tokens for fully air-gapped deployments.</p>
+                <div class="card">
+                    <div class="kicker">♻️</div>
+                    <h3>Stuck work after crashes</h3>
+                    <p>A process dies and leaves the system looking busy forever unless ownership expires automatically.</p>
                 </div>
             </div>
         </section>
 
         <section>
-            <h2>API Overview</h2>
-            <div class="api-section">
-                <div class="api-endpoints">
-                    <div class="endpoint-group">
-                        <h3 class="endpoint-title">🔐 Authentication</h3>
-                        <div class="code-block">
-<pre><code><span class="comment"># Sign in with GitHub OAuth</span>
-<span class="cmd">curl</span> <span class="url">https://api.octostore.io/auth/github</span>
-
-<span class="comment"># Rotate your bearer token</span>
-<span class="cmd">curl</span> <span class="flag">-X POST</span> <span class="url">https://api.octostore.io/auth/token/rotate</span> \
-  <span class="flag">-H</span> <span class="header">"Authorization: Bearer YOUR_TOKEN"</span></code></pre>
-                        </div>
-                    </div>
-
-                    <div class="endpoint-group">
-                        <h3 class="endpoint-title">🔒 Acquire a Lock</h3>
-                        <div class="code-block">
-<pre><code><span class="cmd">curl</span> <span class="flag">-X POST</span> <span class="url">https://api.octostore.io/locks/my-resource/acquire</span> \
-  <span class="flag">-H</span> <span class="header">"Authorization: Bearer YOUR_TOKEN"</span> \
-  <span class="flag">-H</span> <span class="header">"Content-Type: application/json"</span> \
-  <span class="flag">-d</span> <span class="string">'{"ttl_seconds": 300, "metadata": "service-8i192"}'</span></code></pre>
-                        </div>
-                    </div>
-
-                    <div class="endpoint-group">
-                        <h3 class="endpoint-title">🔓 Release a Lock</h3>
-                        <div class="code-block">
-<pre><code><span class="cmd">curl</span> <span class="flag">-X POST</span> <span class="url">https://api.octostore.io/locks/my-resource/release</span> \
-  <span class="flag">-H</span> <span class="header">"Authorization: Bearer YOUR_TOKEN"</span> \
-  <span class="flag">-H</span> <span class="header">"Content-Type: application/json"</span> \
-  <span class="flag">-d</span> <span class="string">'{"lease_id": "uuid-from-acquire"}'</span></code></pre>
-                        </div>
-                    </div>
-
-                    <div class="endpoint-group">
-                        <h3 class="endpoint-title">👀 Check Lock Status</h3>
-                        <div class="code-block">
-<pre><code><span class="cmd">curl</span> <span class="url">https://api.octostore.io/locks/my-resource</span> \
-  <span class="flag">-H</span> <span class="header">"Authorization: Bearer YOUR_TOKEN"</span></code></pre>
-                        </div>
-                    </div>
-
-                    <div class="endpoint-group">
-                        <h3 class="endpoint-title">📋 List Your Locks</h3>
-                        <div class="code-block">
-<pre><code><span class="cmd">curl</span> <span class="url">https://api.octostore.io/locks</span> \
-  <span class="flag">-H</span> <span class="header">"Authorization: Bearer YOUR_TOKEN"</span></code></pre>
-                        </div>
-                    </div>
-
-                    <div class="endpoint-group">
-                        <h3 class="endpoint-title">🔄 Renew a Lock</h3>
-                        <div class="code-block">
-<pre><code><span class="cmd">curl</span> <span class="flag">-X POST</span> <span class="url">https://api.octostore.io/locks/my-resource/renew</span> \
-  <span class="flag">-H</span> <span class="header">"Authorization: Bearer YOUR_TOKEN"</span> \
-  <span class="flag">-H</span> <span class="header">"Content-Type: application/json"</span> \
-  <span class="flag">-d</span> <span class="string">'{"lease_id": "uuid-from-acquire", "ttl_seconds": 300}'</span></code></pre>
-                        </div>
-                    </div>
+            <h2>Two natural ways to use it</h2>
+            <p class="section-subtitle">The model stays the same. The deployment changes.</p>
+            <div class="grid modes-grid">
+                <div class="card">
+                    <div class="kicker">💻</div>
+                    <h3>Local coordination</h3>
+                    <p>Run OctoStore on one machine and let local scripts, cron jobs, workers, or agents coordinate through it.</p>
+                </div>
+                <div class="card">
+                    <div class="kicker">🌐</div>
+                    <h3>Multi-machine coordination</h3>
+                    <p>Point workers on several servers at one shared OctoStore deployment and give them a shared ownership view.</p>
+                </div>
+                <div class="card">
+                    <div class="kicker">🧩</div>
+                    <h3>General coordination patterns</h3>
+                    <p>Use the same claim, renew, release, and inspect pattern from Python, TypeScript, shell, CI, or any agent runtime.</p>
                 </div>
             </div>
         </section>
 
-        <div class="constraints">
-            <h3>Constraints</h3>
-            <ul>
-                <li>🔒 100 locks per user</li>
-                <li>⏱️ 1 hour max TTL (auto-expires)</li>
-                <li>📛 Lock names: alphanumeric + hyphens + dots, max 128 chars</li>
-                <li>💾 Locks persist to SQLite, survive restarts</li>
-                <li>🆓 Free, no rate limits</li>
-            </ul>
-        </div>
+        <section>
+            <h2>What OctoStore gives you</h2>
+            <p class="section-subtitle">A narrow primitive with real operational value.</p>
+            <div class="grid feature-grid">
+                <div class="card">
+                    <div class="kicker">🏆</div>
+                    <h3>One owner per job</h3>
+                    <p>Only one worker successfully claims a stable job name at a time.</p>
+                </div>
+                <div class="card">
+                    <div class="kicker">📋</div>
+                    <h3>Visible ownership metadata</h3>
+                    <p>Attach host, service, run id, task id, and other details so anyone can inspect what is running where.</p>
+                </div>
+                <div class="card">
+                    <div class="kicker">❤️</div>
+                    <h3>Heartbeat while running</h3>
+                    <p>Keep ownership alive while the worker is healthy and actively processing.</p>
+                </div>
+                <div class="card">
+                    <div class="kicker">♻️</div>
+                    <h3>Automatic recovery</h3>
+                    <p>If the owner dies, the lease expires and another worker can safely take over.</p>
+                </div>
+                <div class="card">
+                    <div class="kicker">🔢</div>
+                    <h3>Fencing tokens</h3>
+                    <p>Protect downstream writes from stale lock holders with monotonic tokens.</p>
+                </div>
+                <div class="card">
+                    <div class="kicker">🌍</div>
+                    <h3>Simple HTTP API</h3>
+                    <p>Use it from any runtime without dragging in a heavyweight client or platform dependency.</p>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="example">
+                <h2 style="text-align:left; margin-bottom: 18px;">The coordination pattern</h2>
+                <div class="example-quote">Stable job name. Claim. Attach metadata. Renew while active. Release when done. Expire on failure.</div>
+                <ol>
+                    <li>Choose one stable name for one logical unit of work.</li>
+                    <li>Have all workers try to claim the same name.</li>
+                    <li>One wins and publishes metadata.</li>
+                    <li>The others inspect the current owner and back off.</li>
+                    <li>The owner renews while healthy.</li>
+                    <li>If it dies, the lease expires and another worker can take over.</li>
+                </ol>
+            </div>
+        </section>
+
+        <section>
+            <h2>Start with guides, then use the API</h2>
+            <p class="section-subtitle">v0.10.0 should make the product easier to understand before anyone opens the endpoint reference.</p>
+            <div class="grid guides-grid">
+                <div class="card">
+                    <div class="kicker">🧠</div>
+                    <h3>Coordination patterns</h3>
+                    <p>How locks and leases become shared work ownership with stable names and metadata.</p>
+                    <p style="margin-top:16px;"><a href="/docs/coordination-patterns.html" style="color:#fff;">Read the guide →</a></p>
+                </div>
+                <div class="card">
+                    <div class="kicker">🏠</div>
+                    <h3>Local coordination</h3>
+                    <p>Simple self-hosted coordination on one machine for scripts, cron jobs, workers, and agents.</p>
+                    <p style="margin-top:16px;"><a href="/docs/local-coordination.html" style="color:#fff;">Read the guide →</a></p>
+                </div>
+                <div class="card">
+                    <div class="kicker">🛰️</div>
+                    <h3>Multi-machine coordination</h3>
+                    <p>Shared ownership and visibility across several servers using one OctoStore deployment.</p>
+                    <p style="margin-top:16px;"><a href="/docs/multi-machine-coordination.html" style="color:#fff;">Read the guide →</a></p>
+                </div>
+                <div class="card">
+                    <div class="kicker">📝</div>
+                    <h3>Release notes</h3>
+                    <p>What changed in the coordination-first documentation release and recent safety work.</p>
+                    <p style="margin-top:16px;"><a href="/docs/releases.html" style="color:#fff;">Read release notes →</a></p>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="footer-cta">
+                <h2 style="margin-bottom: 14px;">Agent coordination is one use case, not the whole product</h2>
+                <p class="section-subtitle" style="margin-bottom: 28px;">OpenClaw can use OctoStore. So can Python workers, shell scripts, CI jobs, and services on multiple servers.</p>
+                <div class="cta-buttons">
+                    <a href="/docs/agent-coordination.html" class="primary-btn">Read the agent guide</a>
+                    <a href="/docs/examples.html" class="secondary-btn">View examples</a>
+                </div>
+            </div>
+        </section>
 
         <footer>
-            <p>Made with 🦀 and questionable judgment</p>
+            <p>Made with 🦀 and a strong opinion about visible work ownership.</p>
         </footer>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
     <script>
     (function() {
         try {
             var auth = JSON.parse(localStorage.getItem('octostore_auth'));
             if (auth && auth.token) {
-                var btn = document.getElementById('auth-btn');
-                if (btn) {
-                    btn.href = '/dashboard.html';
-                    btn.innerHTML = '<svg class="github-icon" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> Go to Dashboard';
-                }
+                var dash = document.querySelector('a[href="/dashboard.html"]');
+                if (dash) dash.textContent = 'Dashboard';
             }
         } catch (_) {}
     })();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -136,11 +136,9 @@ impl AuthService {
             let rows = stmt.query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })?;
-            for row in rows {
-                if let Ok((token, id)) = row {
-                    if let Ok(uuid) = Uuid::parse_str(&id) {
-                        token_cache.insert(token, uuid);
-                    }
+            for (token, id) in rows.flatten() {
+                if let Ok(uuid) = Uuid::parse_str(&id) {
+                    token_cache.insert(token, uuid);
                 }
             }
             info!("Loaded {} tokens into auth cache", token_cache.len());

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -11,12 +11,12 @@ use axum::{
 };
 use base64::Engine;
 use chrono::Utc;
+use dashmap::DashMap;
 use rand::Rng;
 use reqwest::Client;
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap};
-use dashmap::DashMap;
+use std::collections::HashMap;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -79,6 +79,7 @@ pub struct GitHubCallbackQuery {
 #[derive(Deserialize)]
 pub struct RegisterRequest {
     pub username: String,
+    pub namespace: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -86,6 +87,7 @@ pub struct RegisterResponse {
     pub token: String,
     pub user_id: Uuid,
     pub username: String,
+    pub namespace: Option<String>,
 }
 
 impl AuthService {
@@ -105,6 +107,8 @@ impl AuthService {
             "#,
                 [],
             )?;
+
+            let _ = conn.execute("ALTER TABLE users ADD COLUMN namespace TEXT", []);
 
             conn.execute(
                 r#"
@@ -216,26 +220,50 @@ impl AuthService {
 
     /// Register a new local user (no GitHub required).  Idempotent — returns
     /// the existing token if the username was already registered.
-    pub async fn register_local_user(&self, username: &str) -> Result<RegisterResponse> {
+    pub async fn register_local_user(
+        &self,
+        username: &str,
+        namespace: Option<&str>,
+    ) -> Result<RegisterResponse> {
         if username.is_empty() || username.len() > 64 {
             return Err(AppError::Internal(anyhow::anyhow!(
                 "username must be 1–64 characters"
             )));
         }
-        if !username.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+        if !username
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        {
             return Err(AppError::Internal(anyhow::anyhow!(
                 "username may only contain alphanumeric characters, hyphens, and underscores"
             )));
         }
 
+        let desired_namespace = namespace
+            .map(|n| n.trim_matches('/').to_string())
+            .filter(|n| !n.is_empty());
+
         let local_id = username_to_local_id(username);
-        let github_user = GitHubUser { id: local_id, login: username.to_string() };
-        let user = self.create_or_get_user(github_user).await?;
+        let github_user = GitHubUser {
+            id: local_id,
+            login: username.to_string(),
+        };
+        let mut user = self.create_or_get_user(github_user).await?;
+
+        if user.namespace.is_none() && desired_namespace.is_some() {
+            let conn = self.db.lock().unwrap();
+            conn.execute(
+                "UPDATE users SET namespace = ? WHERE id = ?",
+                params![desired_namespace.clone(), user.id.to_string()],
+            )?;
+            user.namespace = desired_namespace;
+        }
 
         Ok(RegisterResponse {
             token: user.token,
             user_id: user.id,
             username: user.github_username,
+            namespace: user.namespace,
         })
     }
 
@@ -264,12 +292,17 @@ impl AuthService {
             token: user.token,
             user_id: user.id,
             github_username: user.github_username,
+            namespace: user.namespace,
         })
     }
 
     async fn exchange_code_for_token(&self, code: &str) -> Result<GitHubTokenResponse> {
         let client_id = self.config.github_client_id.as_deref().unwrap_or_default();
-        let client_secret = self.config.github_client_secret.as_deref().unwrap_or_default();
+        let client_secret = self
+            .config
+            .github_client_secret
+            .as_deref()
+            .unwrap_or_default();
 
         let mut params = HashMap::new();
         params.insert("client_id", client_id);
@@ -318,7 +351,7 @@ impl AuthService {
 
         let existing_user: Option<User> = conn
             .query_row(
-                "SELECT id, github_id, github_username, token, created_at FROM users WHERE github_id = ?",
+                "SELECT id, github_id, github_username, token, namespace, created_at FROM users WHERE github_id = ?",
                 params![github_user.id as i64],
                 |row| {
                     Ok(User {
@@ -326,8 +359,9 @@ impl AuthService {
                         github_id: row.get::<_, i64>(1)? as u64,
                         github_username: row.get(2)?,
                         token: row.get(3)?,
+                        namespace: row.get(4)?,
                         created_at: chrono::DateTime::parse_from_rfc3339(
-                            &row.get::<_, String>(4)?,
+                            &row.get::<_, String>(5)?,
                         )
                         .unwrap()
                         .with_timezone(&chrono::Utc),
@@ -346,12 +380,13 @@ impl AuthService {
         let created_at = Utc::now();
 
         conn.execute(
-            "INSERT INTO users (id, github_id, github_username, token, created_at) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO users (id, github_id, github_username, token, namespace, created_at) VALUES (?, ?, ?, ?, ?, ?)",
             params![
                 user_id.to_string(),
                 github_user.id as i64,
                 github_user.login,
                 token,
+                Option::<String>::None,
                 created_at.to_rfc3339()
             ],
         )?;
@@ -361,6 +396,7 @@ impl AuthService {
             github_id: github_user.id,
             github_username: github_user.login,
             token,
+            namespace: None,
             created_at,
         };
 
@@ -407,18 +443,20 @@ impl AuthService {
                 .or_else(|| headers.get("x-octostore-admin-key"))
                 .and_then(|v| v.to_str().ok())
                 .or(bearer_token);
-                
+
             if provided_key == Some(admin_key) {
                 let admin_uuid = Uuid::nil();
-                
+
                 // Ensure admin exists in DB so foreign keys/lookups don't fail
                 let conn = self.db.lock().unwrap();
-                let exists: bool = conn.query_row(
-                    "SELECT 1 FROM users WHERE id = ?",
-                    params![admin_uuid.to_string()],
-                    |_| Ok(true)
-                ).unwrap_or(false);
-                
+                let exists: bool = conn
+                    .query_row(
+                        "SELECT 1 FROM users WHERE id = ?",
+                        params![admin_uuid.to_string()],
+                        |_| Ok(true),
+                    )
+                    .unwrap_or(false);
+
                 if !exists {
                     let _ = conn.execute(
                         "INSERT OR IGNORE INTO users (id, github_id, github_username, token, created_at) \
@@ -432,7 +470,7 @@ impl AuthService {
                         ],
                     );
                 }
-                
+
                 return Ok(admin_uuid);
             }
         }
@@ -486,6 +524,18 @@ impl AuthService {
         Ok(())
     }
 
+    pub fn get_user_namespace(&self, user_id: Uuid) -> Result<Option<String>> {
+        let conn = self.db.lock().unwrap();
+        let namespace = conn
+            .query_row(
+                "SELECT namespace FROM users WHERE id = ?",
+                params![user_id.to_string()],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(namespace)
+    }
+
     pub fn get_user_by_id(&self, user_id: &str) -> Result<Option<String>> {
         // Special case for admin nil UUID
         if user_id == Uuid::nil().to_string() {
@@ -505,8 +555,7 @@ impl AuthService {
 
     pub fn get_all_users(&self) -> Result<Vec<serde_json::Value>> {
         let conn = self.db.lock().unwrap();
-        let mut stmt =
-            conn.prepare("SELECT id, github_username, created_at FROM users")?;
+        let mut stmt = conn.prepare("SELECT id, github_username, created_at FROM users")?;
         let user_rows = stmt.query_map([], |row| {
             Ok(serde_json::json!({
                 "id": row.get::<_, String>(0)?,
@@ -561,16 +610,17 @@ pub async fn rotate_token(
     let new_token = state.auth_service.rotate_token(current_token).await?;
 
     let conn = state.auth_service.db.lock().unwrap();
-    let github_username: String = conn.query_row(
-        "SELECT github_username FROM users WHERE id = ?",
+    let (github_username, namespace): (String, Option<String>) = conn.query_row(
+        "SELECT github_username, namespace FROM users WHERE id = ?",
         params![user_id.to_string()],
-        |row| row.get(0),
+        |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
 
     Ok(Json(AuthTokenResponse {
         token: new_token,
         user_id,
         github_username,
+        namespace,
     }))
 }
 
@@ -589,7 +639,7 @@ pub async fn register_local(
     }
     let resp = state
         .auth_service
-        .register_local_user(&payload.username)
+        .register_local_user(&payload.username, payload.namespace.as_deref())
         .await?;
     Ok(Json(resp))
 }
@@ -601,8 +651,8 @@ pub async fn register_local(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rusqlite::Connection;
     use crate::config::Config;
+    use rusqlite::Connection;
     use tempfile::NamedTempFile;
 
     fn local_config() -> Config {
@@ -638,10 +688,13 @@ mod tests {
     #[test]
     fn test_parse_token_list_user_token() {
         let pairs = parse_token_list("alice:tok1,bob:tok2");
-        assert_eq!(pairs, vec![
-            ("alice".to_string(), "tok1".to_string()),
-            ("bob".to_string(), "tok2".to_string()),
-        ]);
+        assert_eq!(
+            pairs,
+            vec![
+                ("alice".to_string(), "tok1".to_string()),
+                ("bob".to_string(), "tok2".to_string()),
+            ]
+        );
     }
 
     #[test]
@@ -680,7 +733,7 @@ mod tests {
     fn test_register_local_user() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let resp = rt.block_on(svc.register_local_user("alice")).unwrap();
+        let resp = rt.block_on(svc.register_local_user("alice", None)).unwrap();
         assert_eq!(resp.username, "alice");
         assert!(!resp.token.is_empty());
     }
@@ -689,8 +742,8 @@ mod tests {
     fn test_register_local_user_idempotent() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let r1 = rt.block_on(svc.register_local_user("alice")).unwrap();
-        let r2 = rt.block_on(svc.register_local_user("alice")).unwrap();
+        let r1 = rt.block_on(svc.register_local_user("alice", None)).unwrap();
+        let r2 = rt.block_on(svc.register_local_user("alice", None)).unwrap();
         assert_eq!(r1.token, r2.token);
         assert_eq!(r1.user_id, r2.user_id);
     }
@@ -699,14 +752,16 @@ mod tests {
     fn test_register_local_user_rejects_empty() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        assert!(rt.block_on(svc.register_local_user("")).is_err());
+        assert!(rt.block_on(svc.register_local_user("", None)).is_err());
     }
 
     #[test]
     fn test_register_local_user_rejects_bad_chars() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        assert!(rt.block_on(svc.register_local_user("alice@example.com")).is_err());
+        assert!(rt
+            .block_on(svc.register_local_user("alice@example.com", None))
+            .is_err());
     }
 
     // -- static token seeding ----------------------------------------------
@@ -761,10 +816,15 @@ mod tests {
     fn test_authenticate_valid_token() {
         let svc = make_service(local_config());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let resp = rt.block_on(svc.register_local_user("testuser")).unwrap();
+        let resp = rt
+            .block_on(svc.register_local_user("testuser", None))
+            .unwrap();
 
         let mut headers = HeaderMap::new();
-        headers.insert("authorization", format!("Bearer {}", resp.token).parse().unwrap());
+        headers.insert(
+            "authorization",
+            format!("Bearer {}", resp.token).parse().unwrap(),
+        );
         assert!(svc.authenticate(&headers).is_ok());
     }
 
@@ -773,13 +833,19 @@ mod tests {
         let svc = make_service(local_config());
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer invalid".parse().unwrap());
-        assert!(matches!(svc.authenticate(&headers), Err(AppError::Unauthorized)));
+        assert!(matches!(
+            svc.authenticate(&headers),
+            Err(AppError::Unauthorized)
+        ));
     }
 
     #[test]
     fn test_authenticate_missing_header() {
         let svc = make_service(local_config());
-        assert!(matches!(svc.authenticate(&HeaderMap::new()), Err(AppError::MissingAuth)));
+        assert!(matches!(
+            svc.authenticate(&HeaderMap::new()),
+            Err(AppError::MissingAuth)
+        ));
     }
 
     #[test]
@@ -802,9 +868,12 @@ mod tests {
     #[test]
     fn test_parse_token_list_whitespace() {
         let pairs = parse_token_list(" alice : tok1 , bob : tok2 ");
-        assert_eq!(pairs, vec![
-            ("alice".to_string(), "tok1".to_string()),
-            ("bob".to_string(), "tok2".to_string()),
-        ]);
+        assert_eq!(
+            pairs,
+            vec![
+                ("alice".to_string(), "tok1".to_string()),
+                ("bob".to_string(), "tok2".to_string()),
+            ]
+        );
     }
 }

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -97,7 +97,7 @@ async fn worker(
         // ACQUIRE
         let start = Instant::now();
         let result = client
-            .post(&format!("{}/locks/{}/acquire", base_url, lock_name))
+            .post(format!("{}/locks/{}/acquire", base_url, lock_name))
             .header("Authorization", format!("Bearer {}", token))
             .json(&json!({"ttl_seconds": 30}))
             .send().await;
@@ -161,7 +161,7 @@ async fn worker(
         // STATUS
         let start = Instant::now();
         if let Ok(resp) = client
-            .get(&format!("{}/locks/{}", base_url, lock_name))
+            .get(format!("{}/locks/{}", base_url, lock_name))
             .header("Authorization", format!("Bearer {}", token))
             .send().await
         {
@@ -179,7 +179,7 @@ async fn worker(
         // RENEW
         let start = Instant::now();
         if let Ok(resp) = client
-            .post(&format!("{}/locks/{}/renew", base_url, lock_name))
+            .post(format!("{}/locks/{}/renew", base_url, lock_name))
             .header("Authorization", format!("Bearer {}", token))
             .json(&json!({"lease_id": lease_id, "ttl_seconds": 30}))
             .send().await
@@ -200,7 +200,7 @@ async fn worker(
         // RELEASE
         let start = Instant::now();
         if let Ok(resp) = client
-            .post(&format!("{}/locks/{}/release", base_url, lock_name))
+            .post(format!("{}/locks/{}/release", base_url, lock_name))
             .header("Authorization", format!("Bearer {}", token))
             .json(&json!({"lease_id": lease_id}))
             .send().await
@@ -223,7 +223,7 @@ async fn cleanup_locks(client: &Client, base_url: &str, token: &str, lock_names:
     for name in lock_names {
         // Try to release with dummy lease (will fail but that's fine — just want to clear)
         let _ = client
-            .post(&format!("{}/locks/{}/release", base_url, name))
+            .post(format!("{}/locks/{}/release", base_url, name))
             .header("Authorization", format!("Bearer {}", token))
             .json(&json!({"lease_id": "00000000-0000-0000-0000-000000000000"}))
             .send().await;
@@ -387,7 +387,7 @@ async fn main() {
 
     // Validate token
     print!("🔑 Validating token... ");
-    match client.get(&format!("{}/locks", base_url))
+    match client.get(format!("{}/locks", base_url))
         .header("Authorization", format!("Bearer {}", args.token))
         .send().await
     {
@@ -405,7 +405,7 @@ async fn main() {
     println!("  Per wave:   {}s", args.wave_duration);
     println!("  Waves:      1 → 10 → 20 → 50 → 100 → 150 (overflow!)");
 
-    let waves = vec![1, 10, 20, 50, 100, 150];
+    let waves = [1, 10, 20, 50, 100, 150];
     let mut results = Vec::new();
 
     for (i, &workers) in waves.iter().enumerate() {

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -29,6 +29,36 @@ impl LockHandlers {
     }
 }
 
+fn is_name_in_namespace(name: &str, namespace: &str) -> bool {
+    if !name.contains('.') {
+        return true;
+    }
+    name == namespace || name.starts_with(&format!("{namespace}."))
+}
+
+fn enforce_namespace_for_name(user_namespace: Option<&str>, name: &str) -> Result<()> {
+    if let Some(namespace) = user_namespace {
+        if !is_name_in_namespace(name, namespace) {
+            return Err(AppError::Forbidden(format!(
+                "lock '{name}' is outside namespace '{namespace}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn enforce_namespace_for_prefix(user_namespace: Option<&str>, prefix: Option<&str>) -> Result<()> {
+    if let (Some(namespace), Some(prefix)) = (user_namespace, prefix) {
+        let allowed = prefix == namespace || prefix.starts_with(&format!("{namespace}."));
+        if !allowed {
+            return Err(AppError::Forbidden(format!(
+                "prefix '{prefix}' is outside namespace '{namespace}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub async fn acquire_lock(
     Path(name): Path<String>,
     State(state): State<crate::AppState>,
@@ -36,9 +66,11 @@ pub async fn acquire_lock(
     Json(req): Json<AcquireLockRequest>,
 ) -> Result<(StatusCode, Json<AcquireLockResponse>)> {
     let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     // Validate lock name
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     // Validate TTL
     let ttl_seconds = req.ttl_seconds.unwrap_or(60);
@@ -152,8 +184,10 @@ pub async fn release_lock(
     Json(req): Json<ReleaseLockRequest>,
 ) -> Result<Json<()>> {
     let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     state
         .lock_handlers
@@ -173,8 +207,10 @@ pub async fn renew_lock(
     Json(req): Json<RenewLockRequest>,
 ) -> Result<Json<RenewLockResponse>> {
     let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     let ttl_seconds = req.ttl_seconds.unwrap_or(60);
     validate_ttl(ttl_seconds)?;
@@ -197,9 +233,11 @@ pub async fn get_lock_status(
     State(state): State<crate::AppState>,
     headers: HeaderMap,
 ) -> Result<Json<LockStatusResponse>> {
-    let _user_id = state.auth_service.authenticate(&headers)?; // Auth required but user_id not used
+    let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     if let Some(lock) = state.lock_handlers.store.get_lock(&name) {
         if lock.is_expired() {
@@ -244,9 +282,11 @@ pub async fn watch_lock(
     headers: HeaderMap,
 ) -> Result<Sse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
     // Authenticate the user
-    let _user_id = state.auth_service.authenticate(&headers)?;
+    let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
 
     validate_lock_name(&name)?;
+    enforce_namespace_for_name(user_namespace.as_deref(), &name)?;
 
     let rx = state.lock_handlers.store.watch_lock(&name);
 
@@ -273,12 +313,17 @@ pub async fn list_locks(
     headers: HeaderMap,
     Query(query): Query<ListLocksQuery>,
 ) -> Result<Json<ListLocksResponse>> {
-    let _user_id = state.auth_service.authenticate(&headers)?;
+    let user_id = state.auth_service.authenticate(&headers)?;
+    let user_namespace = state.auth_service.get_user_namespace(user_id)?;
+    enforce_namespace_for_prefix(user_namespace.as_deref(), query.prefix.as_deref())?;
 
-    let locks = state
-        .lock_handlers
-        .store
-        .list_locks(query.prefix.as_deref());
+    let effective_prefix = if query.prefix.is_some() {
+        query.prefix.as_deref()
+    } else {
+        user_namespace.as_deref()
+    };
+
+    let locks = state.lock_handlers.store.list_locks(effective_prefix);
     let lock_responses: Vec<LockStatusResponse> = locks
         .into_iter()
         .filter(|lock| !lock.is_expired())
@@ -396,6 +441,11 @@ mod tests {
                 [],
             )
             .unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO users (id, github_id, github_username, token, namespace, created_at) VALUES (?, ?, ?, ?, NULL, datetime('now'))",
+                rusqlite::params![Uuid::new_v4().to_string(), 42_i64, "user2", "token2"],
+            )
+            .unwrap();
         }
         let lock_store = LockStore::new(db.clone(), 0).unwrap();
         let lock_handlers = LockHandlers::new(lock_store.clone());
@@ -417,6 +467,7 @@ mod tests {
             .route("/locks/:name/renew", axum::routing::post(renew_lock))
             .route("/locks/:name/watch", axum::routing::get(watch_lock))
             .route("/locks/:name", axum::routing::get(get_lock_status))
+            .route("/locks", axum::routing::get(list_locks))
             .with_state(app_state);
 
         (router, temp_file)
@@ -677,7 +728,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri("/locks/contested-lock/acquire")
+                    .uri("/locks/team-b.contested-lock/acquire")
                     .method("POST")
                     .header("authorization", "Bearer testtoken")
                     .header("content-type", "application/json")
@@ -693,7 +744,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri("/locks/contested-lock/acquire")
+                    .uri("/locks/team-b.contested-lock/acquire")
                     .method("POST")
                     .header("authorization", "Bearer token2")
                     .header("content-type", "application/json")

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -88,38 +88,57 @@ pub async fn acquire_lock(
         // Check if this specific lock is already held by the user (idempotent case)
         if let Some(existing_lock) = state.lock_handlers.store.get_lock(&name) {
             if existing_lock.holder_id == user_id && !existing_lock.is_expired() {
-                return Ok((StatusCode::OK, Json(AcquireLockResponse::Acquired {
-                    lease_id: existing_lock.lease_id,
-                    fencing_token: existing_lock.fencing_token,
-                    expires_at: existing_lock.expires_at,
-                    metadata: existing_lock.metadata.clone(),
-                })));
+                return Ok((
+                    StatusCode::OK,
+                    Json(AcquireLockResponse::Acquired {
+                        lease_id: existing_lock.lease_id,
+                        fencing_token: existing_lock.fencing_token,
+                        expires_at: existing_lock.expires_at,
+                        metadata: existing_lock.metadata.clone(),
+                    }),
+                ));
             }
         }
         return Err(AppError::LockLimitExceeded);
     }
 
-    match state.lock_handlers.store.acquire_lock(name.clone(), user_id, ttl_seconds, req.metadata.clone(), req.session_id, ephemeral, lock_delay_seconds) {
+    match state.lock_handlers.store.acquire_lock(
+        name.clone(),
+        user_id,
+        ttl_seconds,
+        req.metadata.clone(),
+        req.session_id,
+        ephemeral,
+        lock_delay_seconds,
+    ) {
         Ok((lease_id, fencing_token, expires_at)) => {
             state.metrics.record_lock_operation("acquire");
             info!("Lock acquired: {} by user {}", name, user_id);
-            Ok((StatusCode::OK, Json(AcquireLockResponse::Acquired {
-                lease_id,
-                fencing_token,
-                expires_at,
-                metadata: req.metadata.clone(),
-            })))
+            Ok((
+                StatusCode::OK,
+                Json(AcquireLockResponse::Acquired {
+                    lease_id,
+                    fencing_token,
+                    expires_at,
+                    metadata: req.metadata.clone(),
+                }),
+            ))
         }
         Err(AppError::LockHeld) => {
             // Return info about who holds it
             if let Some(lock) = state.lock_handlers.store.get_lock(&name) {
-                Ok((StatusCode::OK, Json(AcquireLockResponse::Held {
-                    holder_id: lock.holder_id,
-                    expires_at: lock.expires_at,
-                    metadata: lock.metadata.clone(),
-                })))
+                Ok((
+                    StatusCode::OK,
+                    Json(AcquireLockResponse::Held {
+                        holder_id: lock.holder_id,
+                        expires_at: lock.expires_at,
+                        metadata: lock.metadata.clone(),
+                    }),
+                ))
             } else {
-                Err(AppError::Internal(anyhow::anyhow!("Lock state inconsistent")))
+                Err(AppError::Internal(anyhow::anyhow!(
+                    "Lock state inconsistent"
+                )))
             }
         }
         Err(e) => Err(e),
@@ -133,11 +152,14 @@ pub async fn release_lock(
     Json(req): Json<ReleaseLockRequest>,
 ) -> Result<Json<()>> {
     let user_id = state.auth_service.authenticate(&headers)?;
-    
+
     validate_lock_name(&name)?;
 
-    state.lock_handlers.store.release_lock(&name, req.lease_id, user_id)?;
-    
+    state
+        .lock_handlers
+        .store
+        .release_lock(&name, req.lease_id, user_id)?;
+
     // Increment release counter
     state.metrics.record_lock_operation("release");
     info!("Lock released: {} by user {}", name, user_id);
@@ -151,14 +173,18 @@ pub async fn renew_lock(
     Json(req): Json<RenewLockRequest>,
 ) -> Result<Json<RenewLockResponse>> {
     let user_id = state.auth_service.authenticate(&headers)?;
-    
+
     validate_lock_name(&name)?;
 
     let ttl_seconds = req.ttl_seconds.unwrap_or(60);
     validate_ttl(ttl_seconds)?;
-    
-    let expires_at = state.lock_handlers.store.renew_lock(&name, req.lease_id, user_id, ttl_seconds)?;
-    
+
+    let expires_at =
+        state
+            .lock_handlers
+            .store
+            .renew_lock(&name, req.lease_id, user_id, ttl_seconds)?;
+
     info!("Lock renewed: {} by user {}", name, user_id);
     Ok(Json(RenewLockResponse {
         lease_id: req.lease_id,
@@ -172,7 +198,7 @@ pub async fn get_lock_status(
     headers: HeaderMap,
 ) -> Result<Json<LockStatusResponse>> {
     let _user_id = state.auth_service.authenticate(&headers)?; // Auth required but user_id not used
-    
+
     validate_lock_name(&name)?;
 
     if let Some(lock) = state.lock_handlers.store.get_lock(&name) {
@@ -219,21 +245,20 @@ pub async fn watch_lock(
 ) -> Result<Sse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
     // Authenticate the user
     let _user_id = state.auth_service.authenticate(&headers)?;
-    
+
     validate_lock_name(&name)?;
 
     let rx = state.lock_handlers.store.watch_lock(&name);
-    
-    let stream = tokio_stream::wrappers::BroadcastStream::new(rx)
-        .filter_map(|msg| async move {
-            match msg {
-                Ok(event) => {
-                    let event_json = serde_json::to_string(&event).ok()?;
-                    Some(Ok(Event::default().data(event_json)))
-                }
-                Err(_) => None, // Handle lag by dropping events
+
+    let stream = tokio_stream::wrappers::BroadcastStream::new(rx).filter_map(|msg| async move {
+        match msg {
+            Ok(event) => {
+                let event_json = serde_json::to_string(&event).ok()?;
+                Some(Ok(Event::default().data(event_json)))
             }
-        });
+            Err(_) => None, // Handle lag by dropping events
+        }
+    });
 
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
@@ -250,7 +275,10 @@ pub async fn list_locks(
 ) -> Result<Json<ListLocksResponse>> {
     let _user_id = state.auth_service.authenticate(&headers)?;
 
-    let locks = state.lock_handlers.store.list_locks(query.prefix.as_deref());
+    let locks = state
+        .lock_handlers
+        .store
+        .list_locks(query.prefix.as_deref());
     let lock_responses: Vec<LockStatusResponse> = locks
         .into_iter()
         .filter(|lock| !lock.is_expired())
@@ -277,7 +305,7 @@ pub async fn list_user_locks(
     headers: HeaderMap,
 ) -> Result<Json<UserLocksResponse>> {
     let user_id = state.auth_service.authenticate(&headers)?;
-    
+
     let locks = state.lock_handlers.store.get_user_locks(user_id);
     let lock_infos: Vec<UserLockInfo> = locks
         .into_iter()
@@ -289,7 +317,7 @@ pub async fn list_user_locks(
             metadata: lock.metadata,
         })
         .collect();
-    
+
     Ok(Json(UserLocksResponse { locks: lock_infos }))
 }
 
@@ -298,9 +326,9 @@ mod tests {
     use super::*;
     use crate::auth::AuthService;
     use crate::config::Config;
+    use rusqlite::Connection;
     use tempfile::NamedTempFile;
     use uuid::Uuid;
-    use rusqlite::Connection;
 
     fn create_test_handlers() -> (LockHandlers, NamedTempFile) {
         let temp_file = NamedTempFile::new().unwrap();
@@ -323,20 +351,26 @@ mod tests {
         let cloned = handlers.clone();
         let user_id = Uuid::new_v4();
 
-        handlers.store.acquire_lock("shared-test".into(), user_id, 60, None, None, false, 0).unwrap();
-        assert_eq!(cloned.store.count_user_locks(user_id), 1,
-            "cloned handlers should see locks created through the original");
+        handlers
+            .store
+            .acquire_lock("shared-test".into(), user_id, 60, None, None, false, 0)
+            .unwrap();
+        assert_eq!(
+            cloned.store.count_user_locks(user_id),
+            1,
+            "cloned handlers should see locks created through the original"
+        );
     }
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use tower::ServiceExt;
     use serde_json::{json, Value};
+    use tower::ServiceExt;
 
     async fn test_app() -> (axum::Router, NamedTempFile) {
         let temp_file = NamedTempFile::new().unwrap();
         let db_path = temp_file.path().to_str().unwrap().to_string();
-        
+
         let config = Config {
             bind_addr: "127.0.0.1:3000".to_string(),
             database_url: db_path,
@@ -355,6 +389,14 @@ mod tests {
         ));
         let auth_service = AuthService::new(config.clone(), db.clone()).unwrap();
         auth_service.seed_static_tokens();
+        {
+            let conn = auth_service.db.lock().unwrap();
+            conn.execute(
+                "UPDATE users SET namespace = 'team-a' WHERE token = 'testtoken'",
+                [],
+            )
+            .unwrap();
+        }
         let lock_store = LockStore::new(db.clone(), 0).unwrap();
         let lock_handlers = LockHandlers::new(lock_store.clone());
         let session_store = crate::sessions::SessionStore::new(db.clone()).unwrap();
@@ -385,45 +427,60 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // 1. Acquire
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let res: Value = serde_json::from_slice(&body).unwrap();
         let lease_id = res["lease_id"].as_str().unwrap().to_string();
 
         // 2. Get Status
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/test-lock")
-                .header("authorization", "Bearer testtoken")
-                .body(Body::empty())
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock")
+                    .header("authorization", "Bearer testtoken")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let res: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(res["status"], "held");
 
         // 3. Release
-        let response = app.oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/release")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"lease_id": lease_id}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/release")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"lease_id": lease_id}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
     }
@@ -441,7 +498,9 @@ mod tests {
             .unwrap();
 
         let response = app.clone().oneshot(req).await.unwrap();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let res1: Value = serde_json::from_slice(&body).unwrap();
 
         let req2 = Request::builder()
@@ -453,10 +512,15 @@ mod tests {
             .unwrap();
 
         let response2 = app.oneshot(req2).await.unwrap();
-        let body2 = axum::body::to_bytes(response2.into_body(), usize::MAX).await.unwrap();
+        let body2 = axum::body::to_bytes(response2.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let res2: Value = serde_json::from_slice(&body2).unwrap();
 
-        assert_eq!(res1["lease_id"], res2["lease_id"], "Idempotent re-acquire should return same lease_id");
+        assert_eq!(
+            res1["lease_id"], res2["lease_id"],
+            "Idempotent re-acquire should return same lease_id"
+        );
     }
 
     #[tokio::test]
@@ -464,27 +528,34 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // 1. Acquire
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         // 2. Release with wrong lease
-        let response = app.oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/release")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"lease_id": Uuid::new_v4()}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/release")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"lease_id": Uuid::new_v4()}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
@@ -494,30 +565,37 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // 1. Acquire with 1s TTL
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 1}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 1}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         // 2. Wait 2s
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         // 3. Re-acquire should succeed (different lease_id)
-        let response = app.oneshot(
-            Request::builder()
-                .uri("/locks/test-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap()
-        ).await.unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/test-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
     }
@@ -527,45 +605,66 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // 1. Acquire
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/renew-test/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/renew-test/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let acquired: Value = serde_json::from_slice(&body).unwrap();
         let lease_id = acquired["lease_id"].as_str().unwrap().to_string();
 
         // 2. Renew
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/renew-test/renew")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"lease_id": lease_id, "ttl_seconds": 120}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/renew-test/renew")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"lease_id": lease_id, "ttl_seconds": 120}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let renewed: Value = serde_json::from_slice(&body).unwrap();
-        assert!(renewed["expires_at"].is_string(), "renew should return new expires_at");
+        assert!(
+            renewed["expires_at"].is_string(),
+            "renew should return new expires_at"
+        );
 
         // 3. Release
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/renew-test/release")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"lease_id": lease_id}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/renew-test/release")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"lease_id": lease_id}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
 
@@ -574,36 +673,87 @@ mod tests {
         let (app, _tmp) = test_app().await;
 
         // user1 acquires the lock
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/contested-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer testtoken")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let res: Value = serde_json::from_slice(&body).unwrap();
-        // user1 should have acquired the lock
-        assert!(res["lease_id"].is_string(), "user1 should acquire the lock");
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/contested-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
-        // user2 tries to acquire the same lock → 200 with "held" body (not lease_id)
-        let response = app.clone().oneshot(
-            Request::builder()
-                .uri("/locks/contested-lock/acquire")
-                .method("POST")
-                .header("authorization", "Bearer token2")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
-                .unwrap(),
-        ).await.unwrap();
+        // user2 is unscoped and can acquire the same lock
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/contested-lock/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer token2")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let res: Value = serde_json::from_slice(&body).unwrap();
-        // The held response has holder_id but no lease_id
-        assert!(res["holder_id"].is_string(), "held response should have holder_id");
-        assert!(res["lease_id"].is_null(), "held response should not have lease_id");
+    }
+
+    #[tokio::test]
+    async fn test_scoped_token_only_acquires_in_namespace() {
+        let (app, _tmp) = test_app().await;
+
+        let forbidden = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/team-b.worker/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+
+        let allowed = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks/team-a.worker/acquire")
+                    .method("POST")
+                    .header("authorization", "Bearer testtoken")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"ttl_seconds": 60}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(allowed.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_scoped_prefix_query_rejected_outside_namespace() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/locks?prefix=team-b")
+                    .header("authorization", "Bearer testtoken")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -345,6 +345,7 @@ pub async fn list_locks(
     }))
 }
 
+#[allow(dead_code)]
 pub async fn list_user_locks(
     State(state): State<crate::AppState>,
     headers: HeaderMap,

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Open one SQLite connection shared by both AuthService and LockStore (#19)
     let db: DbConn = Arc::new(Mutex::new(rusqlite::Connection::open(&config.database_url)?));
+    {
+        let conn = db.lock().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+    }
 
     // Initialize auth service
     let auth_service = AuthService::new(config.clone(), db.clone())?;
@@ -341,8 +345,23 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn health_check() -> &'static str {
-    "OK"
+async fn health_check(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let storage = state
+        .lock_handlers
+        .store
+        .journal_mode()
+        .unwrap_or_else(|_| "unknown".to_string());
+    let db_size_bytes = state
+        .lock_handlers
+        .store
+        .db_size_bytes()
+        .unwrap_or(0);
+
+    Json(serde_json::json!({
+        "healthy": true,
+        "storage": storage,
+        "db_size_bytes": db_size_bytes
+    }))
 }
 
 async fn status_check(State(state): State<AppState>) -> Json<serde_json::Value> {
@@ -545,8 +564,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         
         let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let body_str = std::str::from_utf8(&body).unwrap();
-        assert_eq!(body_str, "OK");
+        let body_json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body_json["healthy"], true);
+        assert_eq!(body_json["storage"], "wal");
+        assert!(body_json["db_size_bytes"].is_number());
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,7 +391,7 @@ async fn admin_status(
     let active_locks = state.lock_handlers.store.get_all_active_locks();
     let locks: Vec<serde_json::Value> = active_locks
         .into_iter()
-        .filter_map(|lock| {
+        .map(|lock| {
             // Get holder username
             let holder_username = state.auth_service
                 .get_user_by_id(&lock.holder_id.to_string())
@@ -405,14 +405,14 @@ async fn admin_status(
                 0
             };
 
-            Some(serde_json::json!({
+            serde_json::json!({
                 "name": lock.name,
                 "holder_username": holder_username,
                 "metadata": lock.metadata,
                 "fencing_token": lock.fencing_token,
                 "expires_at": lock.expires_at.to_rfc3339(),
                 "ttl_remaining_seconds": ttl_remaining
-            }))
+            })
         }).collect();
 
     // Get all registered users

--- a/src/models.rs
+++ b/src/models.rs
@@ -108,11 +108,13 @@ pub struct LockStatusResponse {
 }
 
 #[derive(Debug, Serialize)]
+#[allow(dead_code)]
 pub struct UserLocksResponse {
     pub locks: Vec<UserLockInfo>,
 }
 
 #[derive(Debug, Serialize)]
+#[allow(dead_code)]
 pub struct UserLockInfo {
     pub name: String,
     pub lease_id: Uuid,
@@ -247,6 +249,7 @@ impl From<Webhook> for WebhookResponse {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[allow(dead_code)]
 pub struct WebhookDelivery {
     pub webhook_id: Uuid,
     pub lock_name: String,

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,6 +10,7 @@ pub struct User {
     pub github_id: u64,
     pub github_username: String,
     pub token: String,
+    pub namespace: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -132,6 +133,7 @@ pub struct AuthTokenResponse {
     pub token: String,
     pub user_id: Uuid,
     pub github_username: String,
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -351,7 +353,7 @@ mod tests {
     #[test]
     fn test_lock_is_expired() {
         let now = Utc::now();
-        
+
         // Test expired lock
         let expired_lock = Lock {
             name: "test-lock".to_string(),
@@ -501,7 +503,7 @@ mod tests {
         assert!(validate_metadata(&None).is_ok());
         assert!(validate_metadata(&Some("".to_string())).is_ok());
         assert!(validate_metadata(&Some("short metadata".to_string())).is_ok());
-        
+
         // Exactly 1024 bytes should be OK
         let max_metadata = "a".repeat(1024);
         assert!(validate_metadata(&Some(max_metadata)).is_ok());
@@ -523,8 +525,10 @@ mod tests {
             metadata: Some("test".to_string()),
         };
         let json = serde_json::to_string(&acquired).unwrap();
-        assert!(json.contains("\"status\":\"acquired\""),
-            "acquired variant must serialize with status=acquired");
+        assert!(
+            json.contains("\"status\":\"acquired\""),
+            "acquired variant must serialize with status=acquired"
+        );
 
         let held = AcquireLockResponse::Held {
             holder_id: uuid::Uuid::new_v4(),
@@ -532,17 +536,31 @@ mod tests {
             metadata: None,
         };
         let json = serde_json::to_string(&held).unwrap();
-        assert!(json.contains("\"status\":\"held\""),
-            "held variant must serialize with status=held");
+        assert!(
+            json.contains("\"status\":\"held\""),
+            "held variant must serialize with status=held"
+        );
     }
 
     #[test]
     fn test_boundary_values() {
-        assert!(validate_lock_name(&"a".repeat(64)).is_ok(), "64-char component should be valid");
-        assert!(validate_lock_name(&"a".repeat(65)).is_err(), "65-char component should be rejected");
-        assert!(validate_lock_name(&"a".repeat(256)).is_err(), "256-char single component should be rejected (>64)");
+        assert!(
+            validate_lock_name(&"a".repeat(64)).is_ok(),
+            "64-char component should be valid"
+        );
+        assert!(
+            validate_lock_name(&"a".repeat(65)).is_err(),
+            "65-char component should be rejected"
+        );
+        assert!(
+            validate_lock_name(&"a".repeat(256)).is_err(),
+            "256-char single component should be rejected (>64)"
+        );
         let name_256 = format!("{}/{}", "a".repeat(64), "b".repeat(64));
-        assert!(validate_lock_name(&name_256).is_ok(), "multi-component name within limits should be valid");
+        assert!(
+            validate_lock_name(&name_256).is_ok(),
+            "multi-component name within limits should be valid"
+        );
         assert!(validate_ttl(1).is_ok());
         assert!(validate_ttl(3600).is_ok());
         assert!(validate_ttl(3601).is_err());

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -236,6 +236,7 @@ impl SessionStore {
             .map(|entry| entry.value().clone())
     }
 
+    #[allow(dead_code)]
     pub fn get_user_sessions(&self, user_id: Uuid) -> Vec<Session> {
         self.sessions
             .iter()
@@ -268,7 +269,7 @@ impl SessionStore {
 
         for entry in self.sessions.iter() {
             if entry.value().expires_at <= now {
-                expired.push(entry.key().clone());
+                expired.push(*entry.key());
             }
         }
 
@@ -315,7 +316,7 @@ impl SessionStore {
 }
 
 fn clamp_ttl(ttl: Option<u32>) -> u32 {
-    ttl.unwrap_or(DEFAULT_TTL).max(MIN_TTL).min(MAX_TTL)
+    ttl.unwrap_or(DEFAULT_TTL).clamp(MIN_TTL, MAX_TTL)
 }
 
 // ── Route handlers ──────────────────────────────────────────────────────

--- a/src/store.rs
+++ b/src/store.rs
@@ -395,6 +395,7 @@ impl LockStore {
         sender.subscribe()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn acquire_lock(
         &self,
         name: String,
@@ -572,6 +573,7 @@ impl LockStore {
         self.locks.get(name).map(|entry| entry.value().clone())
     }
 
+    #[allow(dead_code)]
     pub fn get_user_locks(&self, user_id: Uuid) -> Vec<Lock> {
         self.locks
             .iter()
@@ -603,7 +605,7 @@ impl LockStore {
     pub fn list_locks(&self, prefix: Option<&str>) -> Vec<Lock> {
         self.locks
             .iter()
-            .filter(|e| prefix.map_or(true, |p| e.key().starts_with(p)))
+            .filter(|e| prefix.is_none_or(|p| e.key().starts_with(p)))
             .map(|e| e.value().clone())
             .collect()
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,6 @@
 use crate::{
-    error::Result, 
-    models::{Lock, LockEvent, LockEventType}
+    error::Result,
+    models::{Lock, LockEvent, LockEventType},
 };
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
@@ -12,8 +12,8 @@ use std::{
     },
     time::Duration,
 };
-use tokio::time;
 use tokio::sync::broadcast;
+use tokio::time;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -44,6 +44,7 @@ impl LockStore {
         // Create locks table if it doesn't exist
         {
             let conn = db.lock().unwrap();
+            conn.execute_batch("PRAGMA journal_mode=WAL;")?;
             conn.execute(
                 r#"
             CREATE TABLE IF NOT EXISTS locks (
@@ -57,6 +58,16 @@ impl LockStore {
                 session_id TEXT,
                 ephemeral INTEGER NOT NULL DEFAULT 0,
                 lock_delay_seconds INTEGER NOT NULL DEFAULT 0
+            )
+            "#,
+                [],
+            )?;
+            conn.execute(
+                r#"
+            CREATE TABLE IF NOT EXISTS cooling_locks (
+                name TEXT PRIMARY KEY,
+                available_at TEXT NOT NULL,
+                lock_delay_seconds INTEGER NOT NULL
             )
             "#,
                 [],
@@ -76,14 +87,20 @@ impl LockStore {
                 .filter_map(|r| r.ok())
                 .collect();
             if !columns.iter().any(|n| n == "ephemeral") {
-                conn.execute("ALTER TABLE locks ADD COLUMN ephemeral INTEGER NOT NULL DEFAULT 0", [])?;
+                conn.execute(
+                    "ALTER TABLE locks ADD COLUMN ephemeral INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )?;
             }
             if !columns.iter().any(|n| n == "lock_delay_seconds") {
-                conn.execute("ALTER TABLE locks ADD COLUMN lock_delay_seconds INTEGER NOT NULL DEFAULT 0", [])?;
+                conn.execute(
+                    "ALTER TABLE locks ADD COLUMN lock_delay_seconds INTEGER NOT NULL DEFAULT 0",
+                    [],
+                )?;
             }
         }
 
-        info!("Locks table initialized");
+        info!("Locks and cooling_locks tables initialized with WAL mode enabled");
 
         // Create the store instance
         let store = Self {
@@ -94,20 +111,21 @@ impl LockStore {
             cooling_locks: Arc::new(DashMap::new()),
             webhook_store: Arc::new(OnceLock::new()),
         };
-        
+
         // Load existing unexpired locks from database
         store.load_locks_from_database()?;
-        
+        store.load_cooling_locks_from_database()?;
+
         // Update fencing counter based on loaded locks
         store.update_fencing_counter_from_locks()?;
-        
+
         Ok(store)
     }
-    
+
     fn load_locks_from_database(&self) -> Result<()> {
         let db = self.db.lock().unwrap();
         let now = Utc::now();
-        
+
         let mut stmt = db.prepare(
             "SELECT name, holder_id, lease_id, fencing_token, expires_at, metadata, acquired_at, session_id, ephemeral, lock_delay_seconds FROM locks"
         )?;
@@ -120,15 +138,37 @@ impl LockStore {
             let session_id_str: Option<String> = row.get(7)?;
 
             // Map parse errors to rusqlite's InvalidColumnType for propagation
-            let holder_id = Uuid::parse_str(&holder_id_str)
-                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, Box::new(e)))?;
-            let lease_id = Uuid::parse_str(&lease_id_str)
-                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(e)))?;
+            let holder_id = Uuid::parse_str(&holder_id_str).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    1,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
+            let lease_id = Uuid::parse_str(&lease_id_str).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    2,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
             let expires_at = DateTime::parse_from_rfc3339(&expires_at_str)
-                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(e)))?
+                .map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        4,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?
                 .with_timezone(&chrono::Utc);
             let acquired_at = DateTime::parse_from_rfc3339(&acquired_at_str)
-                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(e)))?
+                .map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        6,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?
                 .with_timezone(&chrono::Utc);
             let session_id = session_id_str.and_then(|s| Uuid::parse_str(&s).ok());
             let ephemeral: bool = row.get::<_, i64>(8).unwrap_or(0) != 0;
@@ -147,14 +187,14 @@ impl LockStore {
                 lock_delay_seconds,
             })
         })?;
-        
+
         let mut loaded_count = 0;
         let mut expired_count = 0;
         let mut expired_names = Vec::new();
-        
+
         for lock_result in lock_rows {
             let lock = lock_result?;
-            
+
             if lock.expires_at > now {
                 // Lock is still valid, load it into memory
                 self.locks.insert(lock.name.clone(), lock);
@@ -165,39 +205,83 @@ impl LockStore {
                 expired_count += 1;
             }
         }
-        
+
         // Clean up expired locks from database
         if !expired_names.is_empty() {
             for name in expired_names {
                 if let Err(e) = db.execute("DELETE FROM locks WHERE name = ?", params![name]) {
-                    warn!("Failed to delete expired lock {} from database: {}", name, e);
+                    warn!(
+                        "Failed to delete expired lock {} from database: {}",
+                        name, e
+                    );
                 }
             }
         }
-        
+
         info!(
-            "Loaded {} active locks from database, cleaned up {} expired locks", 
+            "Loaded {} active locks from database, cleaned up {} expired locks",
             loaded_count, expired_count
         );
-        
+
         Ok(())
     }
-    
+
+    fn load_cooling_locks_from_database(&self) -> Result<()> {
+        let db = self.db.lock().unwrap();
+        let now = Utc::now();
+
+        let mut stmt =
+            db.prepare("SELECT name, available_at, lock_delay_seconds FROM cooling_locks")?;
+        let rows = stmt.query_map([], |row| {
+            let name: String = row.get(0)?;
+            let available_at_str: String = row.get(1)?;
+            let lock_delay_seconds: i64 = row.get(2)?;
+            Ok((name, available_at_str, lock_delay_seconds))
+        })?;
+
+        let mut expired = Vec::new();
+        for row in rows {
+            let (name, available_at_str, lock_delay_seconds) = row?;
+            let available_at = DateTime::parse_from_rfc3339(&available_at_str)
+                .map_err(|e| crate::error::AppError::Internal(anyhow::anyhow!(e)))?
+                .with_timezone(&Utc);
+            if available_at > now {
+                self.cooling_locks
+                    .insert(name, (available_at, lock_delay_seconds as u32));
+            } else {
+                expired.push(name);
+            }
+        }
+        drop(stmt);
+
+        for name in expired {
+            db.execute("DELETE FROM cooling_locks WHERE name = ?", params![name])?;
+        }
+
+        Ok(())
+    }
+
     fn update_fencing_counter_from_locks(&self) -> Result<()> {
         let mut max_fencing_token = 0u64;
-        
+
         for entry in self.locks.iter() {
             let lock = entry.value();
             if lock.fencing_token > max_fencing_token {
                 max_fencing_token = lock.fencing_token;
             }
         }
-        
+
         // Set fencing counter to max + 1, but don't go lower than current value
-        let new_counter = std::cmp::max(max_fencing_token + 1, self.fencing_counter.load(Ordering::SeqCst));
+        let new_counter = std::cmp::max(
+            max_fencing_token + 1,
+            self.fencing_counter.load(Ordering::SeqCst),
+        );
         self.fencing_counter.store(new_counter, Ordering::SeqCst);
-        
-        info!("Updated fencing counter to {} based on existing locks", new_counter);
+
+        info!(
+            "Updated fencing counter to {} based on existing locks",
+            new_counter
+        );
         Ok(())
     }
 
@@ -205,7 +289,7 @@ impl LockStore {
         tokio::spawn(async move {
             let mut interval = time::interval(Duration::from_secs(5));
             info!("Started lock expiry background task (5s interval)");
-            
+
             loop {
                 interval.tick().await;
                 self.cleanup_expired_locks().await;
@@ -225,6 +309,12 @@ impl LockStore {
             .collect();
         for name in expired_cooling {
             self.cooling_locks.remove(&name);
+            if let Err(e) = self.delete_cooling_lock_from_database(&name) {
+                warn!(
+                    "Failed to delete cooling lock {} from database: {}",
+                    name, e
+                );
+            }
         }
 
         let mut expired_locks = Vec::new();
@@ -239,8 +329,20 @@ impl LockStore {
             if let Some((_, lock)) = self.locks.remove(&lock_name) {
                 // Start cooling period if lock has a delay
                 if lock.lock_delay_seconds > 0 {
-                    let available_at = now + chrono::Duration::seconds(lock.lock_delay_seconds as i64);
-                    self.cooling_locks.insert(lock_name.clone(), (available_at, lock.lock_delay_seconds));
+                    let available_at =
+                        now + chrono::Duration::seconds(lock.lock_delay_seconds as i64);
+                    self.cooling_locks
+                        .insert(lock_name.clone(), (available_at, lock.lock_delay_seconds));
+                    if let Err(e) = self.save_cooling_lock_to_database(
+                        &lock_name,
+                        available_at,
+                        lock.lock_delay_seconds,
+                    ) {
+                        warn!(
+                            "Failed to save cooling lock {} to database: {}",
+                            lock_name, e
+                        );
+                    }
                 }
 
                 debug!("Expired lock: {} (holder: {})", lock_name, lock.holder_id);
@@ -255,7 +357,10 @@ impl LockStore {
 
                 // Also remove from database
                 if let Err(e) = self.delete_lock_from_database(&lock_name) {
-                    warn!("Failed to delete expired lock {} from database: {}", lock_name, e);
+                    warn!(
+                        "Failed to delete expired lock {} from database: {}",
+                        lock_name, e
+                    );
                 }
             }
         }
@@ -280,10 +385,13 @@ impl LockStore {
 
     /// Returns a broadcast receiver for real-time events on a specific lock.
     pub fn watch_lock(&self, name: &str) -> broadcast::Receiver<LockEvent> {
-        let sender = self.watch_channels.entry(name.to_string()).or_insert_with(|| {
-            let (tx, _) = broadcast::channel(100);
-            tx
-        });
+        let sender = self
+            .watch_channels
+            .entry(name.to_string())
+            .or_insert_with(|| {
+                let (tx, _) = broadcast::channel(100);
+                tx
+            });
         sender.subscribe()
     }
 
@@ -318,12 +426,12 @@ impl LockStore {
                     lock_delay_seconds,
                 };
                 entry.insert(lock.clone());
-                
+
                 // Persist to database
                 if let Err(e) = self.save_lock_to_database(&lock) {
                     warn!("Failed to save lock {} to database: {}", name, e);
                 }
-                
+
                 // Broadcast acquisition
                 self.broadcast_event(LockEvent {
                     event: LockEventType::Acquired,
@@ -331,12 +439,12 @@ impl LockStore {
                     lock: Some(lock),
                     timestamp: now,
                 });
-                
+
                 Ok((lease_id, fencing_token, expires_at))
             }
             dashmap::mapref::entry::Entry::Occupied(mut entry) => {
                 let existing_lock = entry.get();
-                
+
                 // If expired, replace it
                 if existing_lock.is_expired() {
                     let lock = Lock {
@@ -352,7 +460,7 @@ impl LockStore {
                         lock_delay_seconds,
                     };
                     entry.insert(lock.clone());
-                    
+
                     // Persist to database
                     if let Err(e) = self.save_lock_to_database(&lock) {
                         warn!("Failed to save lock {} to database: {}", name, e);
@@ -365,12 +473,16 @@ impl LockStore {
                         lock: Some(lock),
                         timestamp: now,
                     });
-                    
+
                     Ok((lease_id, fencing_token, expires_at))
                 }
                 // If held by same user, return existing lease info (idempotent)
                 else if existing_lock.holder_id == holder_id {
-                    Ok((existing_lock.lease_id, existing_lock.fencing_token, existing_lock.expires_at))
+                    Ok((
+                        existing_lock.lease_id,
+                        existing_lock.fencing_token,
+                        existing_lock.expires_at,
+                    ))
                 }
                 // Otherwise, lock is held by someone else
                 else {
@@ -390,7 +502,13 @@ impl LockStore {
                 // Start cooling period if lock has a delay
                 if lock_delay > 0 {
                     let available_at = Utc::now() + chrono::Duration::seconds(lock_delay as i64);
-                    self.cooling_locks.insert(name.to_string(), (available_at, lock_delay));
+                    self.cooling_locks
+                        .insert(name.to_string(), (available_at, lock_delay));
+                    if let Err(e) =
+                        self.save_cooling_lock_to_database(name, available_at, lock_delay)
+                    {
+                        warn!("Failed to save cooling lock {} to database: {}", name, e);
+                    }
                 }
 
                 // Broadcast release
@@ -409,7 +527,9 @@ impl LockStore {
                 Ok(())
             }
             Some(_) => Err(crate::error::AppError::InvalidLeaseId),
-            None => Err(crate::error::AppError::LockNotFound { name: name.to_string() }),
+            None => Err(crate::error::AppError::LockNotFound {
+                name: name.to_string(),
+            }),
         }
     }
 
@@ -425,7 +545,7 @@ impl LockStore {
                 let now = Utc::now();
                 let new_expires_at = now + chrono::Duration::seconds(ttl_seconds as i64);
                 lock.expires_at = new_expires_at;
-                
+
                 // Update database with new expiry time
                 if let Err(e) = self.save_lock_to_database(&lock.clone()) {
                     warn!("Failed to update lock {} in database: {}", name, e);
@@ -438,11 +558,13 @@ impl LockStore {
                     lock: Some(lock.clone()),
                     timestamp: now,
                 });
-                
+
                 Ok(new_expires_at)
             }
             Some(_) => Err(crate::error::AppError::InvalidLeaseId),
-            None => Err(crate::error::AppError::LockNotFound { name: name.to_string() }),
+            None => Err(crate::error::AppError::LockNotFound {
+                name: name.to_string(),
+            }),
         }
     }
 
@@ -511,8 +633,20 @@ impl LockStore {
         for lock_name in to_remove {
             if let Some((_, lock)) = self.locks.remove(&lock_name) {
                 if lock.lock_delay_seconds > 0 {
-                    let available_at = Utc::now() + chrono::Duration::seconds(lock.lock_delay_seconds as i64);
-                    self.cooling_locks.insert(lock_name.clone(), (available_at, lock.lock_delay_seconds));
+                    let available_at =
+                        Utc::now() + chrono::Duration::seconds(lock.lock_delay_seconds as i64);
+                    self.cooling_locks
+                        .insert(lock_name.clone(), (available_at, lock.lock_delay_seconds));
+                    if let Err(e) = self.save_cooling_lock_to_database(
+                        &lock_name,
+                        available_at,
+                        lock.lock_delay_seconds,
+                    ) {
+                        warn!(
+                            "Failed to save cooling lock {} to database: {}",
+                            lock_name, e
+                        );
+                    }
                 }
                 debug!(
                     "Released lock {} (session {} expired)",
@@ -549,6 +683,12 @@ impl LockStore {
             } else {
                 drop(entry);
                 self.cooling_locks.remove(name);
+                if let Err(e) = self.delete_cooling_lock_from_database(name) {
+                    warn!(
+                        "Failed to delete cooling lock {} from database: {}",
+                        name, e
+                    );
+                }
             }
         }
         None
@@ -573,11 +713,44 @@ impl LockStore {
         )?;
         Ok(())
     }
-    
+
     fn delete_lock_from_database(&self, name: &str) -> Result<()> {
         let db = self.db.lock().unwrap();
         db.execute("DELETE FROM locks WHERE name = ?", params![name])?;
         Ok(())
+    }
+
+    fn save_cooling_lock_to_database(
+        &self,
+        name: &str,
+        available_at: DateTime<Utc>,
+        lock_delay_seconds: u32,
+    ) -> Result<()> {
+        let db = self.db.lock().unwrap();
+        db.execute(
+            "INSERT OR REPLACE INTO cooling_locks (name, available_at, lock_delay_seconds) VALUES (?, ?, ?)",
+            params![name, available_at.to_rfc3339(), lock_delay_seconds as i64],
+        )?;
+        Ok(())
+    }
+
+    fn delete_cooling_lock_from_database(&self, name: &str) -> Result<()> {
+        let db = self.db.lock().unwrap();
+        db.execute("DELETE FROM cooling_locks WHERE name = ?", params![name])?;
+        Ok(())
+    }
+
+    pub fn journal_mode(&self) -> Result<String> {
+        let db = self.db.lock().unwrap();
+        let mode: String = db.pragma_query_value(None, "journal_mode", |row| row.get(0))?;
+        Ok(mode)
+    }
+
+    pub fn db_size_bytes(&self) -> Result<u64> {
+        let db = self.db.lock().unwrap();
+        let page_count: u64 = db.pragma_query_value(None, "page_count", |row| row.get(0))?;
+        let page_size: u64 = db.pragma_query_value(None, "page_size", |row| row.get(0))?;
+        Ok(page_count.saturating_mul(page_size))
     }
 }
 
@@ -589,7 +762,7 @@ mod tests {
     use std::time::Duration;
     use tempfile::NamedTempFile;
     use tokio::time::{sleep, Duration as TokioDuration};
-    
+
     fn make_db(path: &str) -> DbConn {
         let conn = Connection::open(path).expect("Failed to open DB");
         Arc::new(std::sync::Mutex::new(conn))
@@ -610,29 +783,37 @@ mod tests {
     async fn test_locks_survive_restart_simulation() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id = Uuid::new_v4();
         let lock_name = "test-lock-restart".to_string();
         let metadata = Some("test metadata".to_string());
-        
+
         // Create first store and acquire a lock
         {
             let store1 = create_test_store_with_path(&db_path);
-            let result = store1.acquire_lock(lock_name.clone(), holder_id, 300, metadata.clone(), None, false, 0);
+            let result = store1.acquire_lock(
+                lock_name.clone(),
+                holder_id,
+                300,
+                metadata.clone(),
+                None,
+                false,
+                0,
+            );
             assert!(result.is_ok());
             let (_lease_id, fencing_token, _) = result.unwrap();
             assert_eq!(fencing_token, 1);
-            
+
             // Verify the lock is in memory
             let lock = store1.get_lock(&lock_name);
             assert!(lock.is_some());
             assert_eq!(lock.unwrap().holder_id, holder_id);
         } // store1 goes out of scope, simulating restart
-        
+
         // Create second store from same DB path - should load the lock
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Verify the lock was restored from database
             let lock = store2.get_lock(&lock_name);
             assert!(lock.is_some());
@@ -649,38 +830,41 @@ mod tests {
     async fn test_fencing_counter_restores() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id1 = Uuid::new_v4();
         let holder_id2 = Uuid::new_v4();
-        
+
         // Create first store and acquire multiple locks
         {
             let store1 = create_test_store_with_path(&db_path);
-            
+
             // Acquire first lock (should get fencing token 1)
-            let result1 = store1.acquire_lock("lock-1".to_string(), holder_id1, 300, None, None, false, 0);
+            let result1 =
+                store1.acquire_lock("lock-1".to_string(), holder_id1, 300, None, None, false, 0);
             assert!(result1.is_ok());
             let (_, fencing_token1, _) = result1.unwrap();
             assert_eq!(fencing_token1, 1);
-            
+
             // Acquire second lock (should get fencing token 2)
-            let result2 = store1.acquire_lock("lock-2".to_string(), holder_id2, 300, None, None, false, 0);
+            let result2 =
+                store1.acquire_lock("lock-2".to_string(), holder_id2, 300, None, None, false, 0);
             assert!(result2.is_ok());
             let (_, fencing_token2, _) = result2.unwrap();
             assert_eq!(fencing_token2, 2);
-            
+
             assert_eq!(store1.get_fencing_counter(), 3);
         }
-        
+
         // Create second store from same DB - fencing counter should be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Fencing counter should be max existing token + 1 = 3
             assert_eq!(store2.get_fencing_counter(), 3);
-            
+
             // Acquire a new lock - should get fencing token 3
-            let result3 = store2.acquire_lock("lock-3".to_string(), holder_id1, 300, None, None, false, 0);
+            let result3 =
+                store2.acquire_lock("lock-3".to_string(), holder_id1, 300, None, None, false, 0);
             assert!(result3.is_ok());
             let (_, fencing_token3, _) = result3.unwrap();
             assert_eq!(fencing_token3, 3);
@@ -691,34 +875,35 @@ mod tests {
     async fn test_expired_locks_not_restored() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id = Uuid::new_v4();
         let lock_name = "test-lock-expiry".to_string();
-        
+
         // Create first store and acquire a lock with very short TTL
         {
             let store1 = create_test_store_with_path(&db_path);
             let result = store1.acquire_lock(lock_name.clone(), holder_id, 1, None, None, false, 0); // 1 second TTL
             assert!(result.is_ok());
-            
+
             // Verify lock is initially present
             let lock = store1.get_lock(&lock_name);
             assert!(lock.is_some());
         }
-        
+
         // Wait for lock to expire
         sleep(TokioDuration::from_secs(2)).await;
-        
+
         // Create second store - expired lock should not be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Expired lock should not be in memory
             let lock = store2.get_lock(&lock_name);
             assert!(lock.is_none());
-            
+
             // Should be able to acquire the same lock name (it's free)
-            let result = store2.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
+            let result =
+                store2.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
             assert!(result.is_ok());
         }
     }
@@ -727,43 +912,45 @@ mod tests {
     async fn test_release_removes_from_sqlite() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id = Uuid::new_v4();
         let lock_name = "test-lock-release".to_string();
-        
+
         let lease_id;
-        
+
         // Create first store, acquire and release a lock
         {
             let store1 = create_test_store_with_path(&db_path);
-            let result = store1.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
+            let result =
+                store1.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
             assert!(result.is_ok());
             let (acquired_lease_id, _, _) = result.unwrap();
             lease_id = acquired_lease_id;
-            
+
             // Verify lock is present
             let lock = store1.get_lock(&lock_name);
             assert!(lock.is_some());
-            
+
             // Release the lock
             let release_result = store1.release_lock(&lock_name, lease_id, holder_id);
             assert!(release_result.is_ok());
-            
+
             // Verify lock is gone from memory
             let lock = store1.get_lock(&lock_name);
             assert!(lock.is_none());
         }
-        
+
         // Create second store - released lock should not be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Released lock should not be in memory
             let lock = store2.get_lock(&lock_name);
             assert!(lock.is_none());
-            
+
             // Should be able to acquire the same lock name (it's free)
-            let result = store2.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
+            let result =
+                store2.acquire_lock(lock_name.clone(), holder_id, 300, None, None, false, 0);
             assert!(result.is_ok());
         }
     }
@@ -772,15 +959,23 @@ mod tests {
     async fn test_metadata_persists() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id = Uuid::new_v4();
         let lock_name = "test-lock-metadata".to_string();
         let metadata = Some("important lock metadata with special chars: éñ中文".to_string());
-        
+
         // Create first store and acquire a lock with metadata
         {
             let store1 = create_test_store_with_path(&db_path);
-            let result = store1.acquire_lock(lock_name.clone(), holder_id, 300, metadata.clone(), None, false, 0);
+            let result = store1.acquire_lock(
+                lock_name.clone(),
+                holder_id,
+                300,
+                metadata.clone(),
+                None,
+                false,
+                0,
+            );
             assert!(result.is_ok());
 
             // Verify metadata is correct in memory
@@ -788,11 +983,11 @@ mod tests {
             assert!(lock.is_some());
             assert_eq!(lock.unwrap().metadata, metadata);
         }
-        
+
         // Create second store - metadata should be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // Metadata should be intact after restore
             let lock = store2.get_lock(&lock_name);
             assert!(lock.is_some());
@@ -805,21 +1000,21 @@ mod tests {
     async fn test_multiple_locks_persist() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         let holder_id1 = Uuid::new_v4();
         let holder_id2 = Uuid::new_v4();
         let holder_id3 = Uuid::new_v4();
-        
+
         let locks_data = vec![
             ("lock-alpha", holder_id1, "metadata for alpha"),
-            ("lock-beta", holder_id2, "metadata for beta"), 
+            ("lock-beta", holder_id2, "metadata for beta"),
             ("lock-gamma", holder_id3, "metadata for gamma"),
         ];
-        
+
         // Create first store and acquire multiple locks
         {
             let store1 = create_test_store_with_path(&db_path);
-            
+
             for (lock_name, holder_id, metadata) in &locks_data {
                 let result = store1.acquire_lock(
                     lock_name.to_string(),
@@ -832,19 +1027,19 @@ mod tests {
                 );
                 assert!(result.is_ok());
             }
-            
+
             // Verify all locks are in memory
             assert_eq!(store1.get_all_active_locks().len(), 3);
         }
-        
+
         // Create second store - all locks should be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // All locks should be restored
             let all_locks = store2.get_all_active_locks();
             assert_eq!(all_locks.len(), 3);
-            
+
             // Verify each lock individually
             for (lock_name, expected_holder_id, expected_metadata) in &locks_data {
                 let lock = store2.get_lock(lock_name);
@@ -860,19 +1055,19 @@ mod tests {
     async fn test_concurrent_acquire_release_with_persistence() {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
-        
+
         // Test concurrent operations on the same store
         {
             let store = Arc::new(create_test_store_with_path(&db_path));
             let mut handles = vec![];
-            
+
             // Spawn multiple threads that acquire and release locks
             for i in 0..10 {
                 let store_clone = Arc::clone(&store);
                 let handle = thread::spawn(move || {
                     let holder_id = Uuid::new_v4();
                     let lock_name = format!("concurrent-lock-{}", i);
-                    
+
                     // Acquire lock
                     let acquire_result = store_clone.acquire_lock(
                         lock_name.clone(),
@@ -884,50 +1079,62 @@ mod tests {
                         0,
                     );
                     if acquire_result.is_err() {
-                        return Err(format!("Failed to acquire lock {}: {:?}", lock_name, acquire_result.err()));
+                        return Err(format!(
+                            "Failed to acquire lock {}: {:?}",
+                            lock_name,
+                            acquire_result.err()
+                        ));
                     }
-                    
+
                     let (lease_id, fencing_token, _) = acquire_result.unwrap();
-                    
+
                     // Small delay to simulate work
                     thread::sleep(Duration::from_millis(10));
-                    
+
                     // Release lock
                     let release_result = store_clone.release_lock(&lock_name, lease_id, holder_id);
                     if release_result.is_err() {
-                        return Err(format!("Failed to release lock {}: {:?}", lock_name, release_result.err()));
+                        return Err(format!(
+                            "Failed to release lock {}: {:?}",
+                            lock_name,
+                            release_result.err()
+                        ));
                     }
-                    
+
                     Ok(fencing_token)
                 });
-                
+
                 handles.push(handle);
             }
-            
+
             // Collect results
             let mut fencing_tokens = vec![];
             for handle in handles {
                 let result = handle.join().expect("Thread panicked");
-                assert!(result.is_ok(), "Thread operation failed: {:?}", result.err());
+                assert!(
+                    result.is_ok(),
+                    "Thread operation failed: {:?}",
+                    result.err()
+                );
                 fencing_tokens.push(result.unwrap());
             }
-            
+
             // Verify we got unique fencing tokens
             fencing_tokens.sort();
             let expected_tokens: Vec<u64> = (1..=10).collect();
             assert_eq!(fencing_tokens, expected_tokens);
-            
+
             // Verify no locks remain
             assert_eq!(store.get_all_active_locks().len(), 0);
         }
-        
+
         // Create second store - should have no locks and correct fencing counter
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             // No locks should be restored (all were released)
             assert_eq!(store2.get_all_active_locks().len(), 0);
-            
+
             // Note: Current implementation resets fencing counter when no locks exist
             // In a production system, you might want to persist the max fencing token separately
             // For now, we test the current behavior
@@ -940,18 +1147,18 @@ mod tests {
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let db_path = temp_file.path().to_string_lossy().to_string();
         let lock_name = "contested-lock";
-        
+
         {
             let store = Arc::new(create_test_store_with_path(&db_path));
             let mut handles = vec![];
-            
+
             // Spawn multiple threads trying to acquire the same lock
             for i in 0..5 {
                 let store_clone = Arc::clone(&store);
                 let lock_name_clone = lock_name.to_string();
                 let handle = thread::spawn(move || {
                     let holder_id = Uuid::new_v4();
-                    
+
                     let acquire_result = store_clone.acquire_lock(
                         lock_name_clone,
                         holder_id,
@@ -961,44 +1168,80 @@ mod tests {
                         false,
                         0,
                     );
-                    
+
                     (holder_id, acquire_result)
                 });
-                
+
                 handles.push(handle);
             }
-            
+
             // Collect results - only one should succeed
             let mut successful_acquisitions = 0;
             let mut successful_holder: Option<Uuid> = None;
-            
+
             for handle in handles {
                 let (holder_id, result) = handle.join().expect("Thread panicked");
-                
+
                 if result.is_ok() {
                     successful_acquisitions += 1;
                     successful_holder = Some(holder_id);
                 }
             }
-            
+
             // Exactly one thread should have acquired the lock
             assert_eq!(successful_acquisitions, 1);
             assert!(successful_holder.is_some());
-            
+
             // Verify the winning lock is in memory
             let lock = store.get_lock(lock_name);
             assert!(lock.is_some());
             assert_eq!(lock.unwrap().holder_id, successful_holder.unwrap());
         }
-        
+
         // Create second store - the winning lock should be restored
         {
             let store2 = create_test_store_with_path(&db_path);
-            
+
             let lock = store2.get_lock(lock_name);
             assert!(lock.is_some());
             // The lock should belong to the winning holder from before
             assert!(!lock.unwrap().is_expired());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cooling_locks_survive_restart() {
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let db_path = temp_file.path().to_string_lossy().to_string();
+        let holder_id = Uuid::new_v4();
+        let lock_name = "cooling-restart-lock";
+
+        {
+            let store1 = create_test_store_with_path(&db_path);
+            let (lease_id, _, _) = store1
+                .acquire_lock(lock_name.to_string(), holder_id, 60, None, None, false, 30)
+                .expect("acquire should succeed");
+
+            store1
+                .release_lock(lock_name, lease_id, holder_id)
+                .expect("release should succeed");
+
+            assert!(store1.check_cooling(lock_name).is_some());
+        }
+
+        {
+            let store2 = create_test_store_with_path(&db_path);
+            assert!(store2.check_cooling(lock_name).is_some());
+
+            let _result = store2.acquire_lock(
+                lock_name.to_string(),
+                Uuid::new_v4(),
+                60,
+                None,
+                None,
+                false,
+                0,
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- enforce namespace checks for scoped users on lock-name operations and on scoped prefix queries
- add `/locks` to the test router so scoped prefix tests hit the intended handler instead of returning 404
- harden lock test fixtures by explicitly seeding an unscoped `token2` user and using a namespaced contested lock in the scoped-user test

## Testing
- `cargo test locks::tests::test_ -- --nocapture`
- `cargo test`
