### PR TITLE
Update workflows for Node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check

--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout metrics branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.METRICS_BRANCH }}
           path: metrics
           fetch-depth: 0
 
       - name: Checkout repo (for release data)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: repo
           sparse-checkout: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -31,7 +31,7 @@ jobs:
       usage_summary: ${{ steps.usage.outputs.summary }}
     steps:
       - name: Checkout metrics branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.METRICS_BRANCH }}
           path: metrics
@@ -191,7 +191,7 @@ jobs:
       - name: Create or update outage issue
         if: ${{ steps.eval.outputs.status == 'fail' }}
         id: outage_issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -239,7 +239,7 @@ jobs:
       - name: Auto-close outage issue on recovery
         if: ${{ steps.eval.outputs.status == 'ok' }}
         id: recover
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner  = context.repo.owner;

--- a/.github/workflows/no-ai-authors.yml
+++ b/.github/workflows/no-ai-authors.yml
@@ -10,7 +10,7 @@ jobs:
     name: Verify no AI commit authors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check for AI-attributed commits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -59,7 +59,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Summary
- update checkout actions from v4 to v5
- update github-script actions from v7 to v8
- removes Node.js 20 deprecation warnings from the uptime workflow and related jobs

## Verification
- grep confirmed no remaining actions/checkout@v4 or actions/github-script@v7 references
- uptime workflow passed before this follow-up; this changes only action versions
