### PR TITLE
feat: show live interactions on homepage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -106,13 +106,31 @@
         }
         .example ol { margin-left: 22px; color: var(--text-secondary); }
         .example li { margin: 10px 0; }
+
+        .live-panel {
+            background: linear-gradient(180deg, rgba(16,185,129,0.08), rgba(17,17,17,0.96));
+            border: 1px solid rgba(16,185,129,0.18); border-radius: 20px; padding: 32px;
+            box-shadow: var(--shadow);
+        }
+        .live-header { display: flex; align-items: center; justify-content: space-between; gap: 18px; margin-bottom: 22px; flex-wrap: wrap; }
+        .live-status { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 999px; background: rgba(16,185,129,0.1); color: #86efac; border: 1px solid rgba(16,185,129,0.25); font-weight: 600; }
+        .live-dot { width: 8px; height: 8px; border-radius: 50%; background: #10b981; box-shadow: 0 0 18px #10b981; }
+        .live-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 24px; }
+        .live-stat { background: rgba(0,0,0,0.22); border: 1px solid var(--border); border-radius: 14px; padding: 18px; }
+        .live-stat strong { display: block; color: #fff; font-size: 1.8rem; line-height: 1; margin-bottom: 8px; }
+        .live-stat span { color: var(--text-muted); font-size: 0.92rem; }
+        .interaction-list { display: grid; gap: 10px; }
+        .interaction-item { display: flex; justify-content: space-between; gap: 16px; align-items: center; padding: 12px 14px; border-radius: 12px; background: rgba(0,0,0,0.2); border: 1px solid var(--border); }
+        .interaction-action { color: #fff; font-weight: 600; }
+        .interaction-meta { color: var(--text-muted); font-family: 'SF Mono', Monaco, monospace; font-size: 0.85rem; }
+        .interaction-empty { color: var(--text-muted); padding: 14px; border: 1px dashed var(--border); border-radius: 12px; }
         .footer-cta {
             text-align: center; padding: 44px 28px; border: 1px solid var(--border); border-radius: 20px; background: var(--bg-secondary);
         }
         footer { text-align: center; margin: 90px 0 60px; padding-top: 32px; border-top: 1px solid var(--border); color: var(--text-muted); }
         @media (max-width: 920px) {
             h1 { font-size: 3rem; }
-            .problem-grid, .feature-grid, .stack-grid { grid-template-columns: 1fr; }
+            .problem-grid, .feature-grid, .stack-grid, .live-grid { grid-template-columns: 1fr; }
         }
         @media (max-width: 640px) {
             .container { padding: 0 16px; }
@@ -149,6 +167,29 @@
             </div>
             <div class="statement"><strong>Core stack:</strong> Skills provide capabilities. The marketplace distributes them. OctoStore coordinates execution.</div>
         </header>
+
+
+
+        <section>
+            <div class="live-panel">
+                <div class="live-header">
+                    <div>
+                        <h2 style="text-align:left; margin-bottom: 10px;">Live OctoStore interactions</h2>
+                        <p style="color: var(--text-muted);">Pulled directly from the running API so visitors can see coordination traffic as it happens.</p>
+                    </div>
+                    <div class="live-status"><span class="live-dot"></span><span id="liveStatus">Connecting…</span></div>
+                </div>
+                <div class="live-grid">
+                    <div class="live-stat"><strong id="liveLocks">—</strong><span>active locks</span></div>
+                    <div class="live-stat"><strong id="liveUsers">—</strong><span>registered users</span></div>
+                    <div class="live-stat"><strong id="liveAcquires">—</strong><span>total acquires</span></div>
+                    <div class="live-stat"><strong id="liveReleases">—</strong><span>total releases</span></div>
+                </div>
+                <div class="interaction-list" id="interactionList">
+                    <div class="interaction-empty">Waiting for live traffic…</div>
+                </div>
+            </div>
+        </section>
 
         <section>
             <h2>The problem</h2>
@@ -263,6 +304,56 @@
     </div>
 
     <script>
+
+    (function() {
+        const api = 'https://api.octostore.io';
+        const fmt = new Intl.NumberFormat();
+        function setText(id, value) {
+            const el = document.getElementById(id);
+            if (el) el.textContent = value;
+        }
+        function timeAgo(ts) {
+            const seconds = Math.max(0, Math.floor(Date.now() / 1000 - ts));
+            if (seconds < 5) return 'just now';
+            if (seconds < 60) return `${seconds}s ago`;
+            const mins = Math.floor(seconds / 60);
+            return `${mins}m ago`;
+        }
+        function renderInteractions(items) {
+            const list = document.getElementById('interactionList');
+            if (!list) return;
+            if (!items || items.length === 0) {
+                list.innerHTML = '<div class="interaction-empty">No live interactions recorded yet. Try the API or open the dashboard.</div>';
+                return;
+            }
+            list.innerHTML = items.slice(0, 6).map(item => `
+                <div class="interaction-item">
+                    <div>
+                        <div class="interaction-action">${item.ok ? '✓' : '⚠'} ${item.action || item.endpoint}</div>
+                        <div class="interaction-meta">/${item.endpoint} · ${item.duration_ms || '0.0'}ms</div>
+                    </div>
+                    <div class="interaction-meta">${timeAgo(item.timestamp)}</div>
+                </div>
+            `).join('');
+        }
+        async function refreshLive() {
+            try {
+                const res = await fetch(`${api}/status`, { cache: 'no-store' });
+                if (!res.ok) throw new Error(`status ${res.status}`);
+                const data = await res.json();
+                setText('liveStatus', 'Live');
+                setText('liveLocks', fmt.format(data.active_locks || 0));
+                setText('liveUsers', fmt.format(data.total_users || 0));
+                setText('liveAcquires', fmt.format(data.total_acquires || 0));
+                setText('liveReleases', fmt.format(data.total_releases || 0));
+                renderInteractions(data.recent_interactions || []);
+            } catch (_) {
+                setText('liveStatus', 'API unreachable');
+            }
+        }
+        refreshLive();
+        setInterval(refreshLive, 10000);
+    })();
     (function() {
         try {
             var auth = JSON.parse(localStorage.getItem('octostore_auth'));

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,8 +312,9 @@ async fn main() -> anyhow::Result<()> {
         // Health check
         .route("/health", get(health_check))
         .fallback(api_docs)
-        // Public status endpoint (no auth)
+        // Public status endpoints (no auth)
         .route("/status", get(status_check))
+        .route("/interactions", get(interactions_check))
         // Admin routes
         .route("/admin/status", get(admin_status))
         .route("/admin/metrics/timeseries", get(timeseries_endpoint))
@@ -389,7 +390,23 @@ async fn status_check(State(state): State<AppState>) -> Json<serde_json::Value> 
         "active_locks": active_locks.len(),
         "total_users": users.len(),
         "total_acquires": total_acquires,
-        "total_releases": total_releases
+        "total_releases": total_releases,
+        "recent_interactions": state.metrics.recent_interactions(10)
+    }))
+}
+
+async fn interactions_check(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Json<serde_json::Value> {
+    let limit = params
+        .get("limit")
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(20);
+
+    Json(serde_json::json!({
+        "status": "ok",
+        "interactions": state.metrics.recent_interactions(limit)
     }))
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -42,6 +42,28 @@ impl Default for EndpointMetrics {
     }
 }
 
+
+#[derive(Debug, Clone)]
+pub struct InteractionEvent {
+    pub timestamp: u64,
+    pub action: String,
+    pub endpoint: String,
+    pub ok: bool,
+    pub duration_ms: f64,
+}
+
+impl InteractionEvent {
+    fn to_json(&self) -> Value {
+        json!({
+            "timestamp": self.timestamp,
+            "action": self.action,
+            "endpoint": self.endpoint,
+            "ok": self.ok,
+            "duration_ms": format!("{:.1}", self.duration_ms)
+        })
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MetricsBucket {
     pub timestamp: u64,  // Unix timestamp in seconds
@@ -281,6 +303,7 @@ pub struct Metrics {
     pub cache_hits: AtomicU64,
     pub cache_misses: AtomicU64,
     pub timeseries: TimeSeriesMetrics,
+    recent_interactions: RwLock<VecDeque<InteractionEvent>>,
 }
 
 impl Default for Metrics {
@@ -300,6 +323,7 @@ impl Default for Metrics {
             cache_hits: AtomicU64::new(0),
             cache_misses: AtomicU64::new(0),
             timeseries: TimeSeriesMetrics::default(),
+            recent_interactions: RwLock::new(VecDeque::with_capacity(100)),
         }
     }
 }
@@ -335,6 +359,48 @@ impl Metrics {
         self.total_requests.fetch_add(1, Ordering::Relaxed);
         self.timeseries.record_request();
         endpoint_metrics.record(duration_ms, is_error);
+        self.record_interaction(endpoint, duration_ms, !is_error);
+    }
+
+    fn record_interaction(&self, endpoint: &str, duration_ms: f64, ok: bool) {
+        let action = match endpoint {
+            "acquire" => "lock acquired",
+            "release" => "lock released",
+            "renew" => "lease renewed",
+            "status" => "lock inspected",
+            "list" => "locks listed",
+            "auth" => "auth request",
+            _ => "request",
+        };
+
+        let event = InteractionEvent {
+            timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
+            action: action.to_string(),
+            endpoint: endpoint.to_string(),
+            ok,
+            duration_ms,
+        };
+
+        if let Ok(mut interactions) = self.recent_interactions.write() {
+            interactions.push_front(event);
+            while interactions.len() > 100 {
+                interactions.pop_back();
+            }
+        }
+    }
+
+    pub fn recent_interactions(&self, limit: usize) -> Value {
+        let limit = limit.clamp(1, 100);
+        if let Ok(interactions) = self.recent_interactions.read() {
+            let events: Vec<Value> = interactions
+                .iter()
+                .take(limit)
+                .map(InteractionEvent::to_json)
+                .collect();
+            json!(events)
+        } else {
+            json!([])
+        }
     }
     
     pub fn record_lock_operation(&self, operation: &str) {
@@ -402,7 +468,8 @@ impl Metrics {
                 "cache_hits": self.cache_hits.load(Ordering::Relaxed),
                 "cache_misses": self.cache_misses.load(Ordering::Relaxed),
             },
-            "memory_bytes": memory_bytes
+            "memory_bytes": memory_bytes,
+            "recent_interactions": self.recent_interactions(20)
         })
     }
 }


### PR DESCRIPTION
## Summary
- Add an in-memory public recent interaction feed backed by request metrics
- Expose recent interactions on /status and /interactions?limit=N
- Add a homepage live panel that polls the live API for counters and recent coordination activity

## Why
The homepage currently talks about coordination but does not show that the hosted API is actually being used. This makes live activity visible without requiring an admin key.

## Test
- cargo test