### PR TITLE
feat: enable WAL-backed crash recovery health

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -366,8 +366,16 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn health_check() -> &'static str {
-    "OK"
+async fn health_check(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let db_size_bytes = std::fs::metadata(&state.config.database_url)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+
+    Json(serde_json::json!({
+        "status": "ok",
+        "storage": "wal",
+        "db_size_bytes": db_size_bytes,
+    }))
 }
 
 async fn status_check(State(state): State<AppState>) -> Json<serde_json::Value> {
@@ -570,7 +578,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_health_check() {
+    async fn test_health_check_reports_wal_storage_details() {
         let app = create_test_app().await;
 
         let response = app
@@ -588,8 +596,10 @@ mod tests {
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
-        let body_str = std::str::from_utf8(&body).unwrap();
-        assert_eq!(body_str, "OK");
+        let body_json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body_json["status"], "ok");
+        assert_eq!(body_json["storage"], "wal");
+        assert!(body_json["db_size_bytes"].as_u64().is_some());
     }
 
     #[tokio::test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -21,6 +21,12 @@ use uuid::Uuid;
 /// [`crate::auth::AuthService`] so the process opens only one file handle.
 pub type DbConn = Arc<Mutex<Connection>>;
 
+pub fn configure_sqlite_connection(db: &DbConn) -> Result<()> {
+    let conn = db.lock().unwrap();
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    Ok(())
+}
+
 /// In-memory lock store backed by SQLite for durability.
 ///
 /// Locks live in a `DashMap` for fast concurrent access. Every mutation is
@@ -79,6 +85,8 @@ impl AcquireLockOptions {
 
 impl LockStore {
     pub fn new(db: DbConn, initial_fencing_token: u64) -> Result<Self> {
+        configure_sqlite_connection(&db)?;
+
         // Create locks table if it doesn't exist
         {
             let conn = db.lock().unwrap();
@@ -703,6 +711,21 @@ mod tests {
 
     fn create_test_store_with_path(db_path: &str) -> LockStore {
         LockStore::new(make_db(db_path), 1).expect("Failed to create store")
+    }
+
+    #[test]
+    fn test_lock_store_enables_wal_mode() {
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let db_path = temp_file.path().to_string_lossy().to_string();
+        let db = make_db(&db_path);
+
+        let _store = LockStore::new(db.clone(), 1).expect("Failed to create store");
+
+        let conn = db.lock().unwrap();
+        let mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .expect("Failed to read journal mode");
+        assert_eq!(mode.to_lowercase(), "wal");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- enable SQLite WAL mode when the shared lock-store DB connection starts
- keep restart durability tests and add an explicit WAL-mode regression test
- change /health to return JSON storage metadata including WAL and DB size

Closes #23

## Test Plan
- cargo test
- cargo build
- run target/debug/octostore locally and curl /health; verify PRAGMA journal_mode returns wal