### PR TITLE
Release v0.13.1: restore static-token lock acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Octostore will be documented in this file.
 
+## v0.13.1 - 2026-07-18
+
+### Fixed
+
+- Restore authenticated lock acquisition for static-token and local users without a namespace. Namespace checks now treat a SQL `NULL` as the intended unrestricted namespace instead of returning `500 Internal Server Error`.
+
 ## v0.13.0 - 2026-07-18
 
 OctoStore now leads with its smallest useful promise: elect one leader from any process in two HTTP calls, without an account, API key, SDK, or cluster to operate. Agent fleets and self-hosted task coordination remain dedicated paths rather than prerequisites.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "octostore"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octostore"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "Simple leader election over HTTP with self-hosted task and agent coordination"
 license = "MIT"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -528,9 +528,10 @@ impl AuthService {
             .query_row(
                 "SELECT namespace FROM users WHERE id = ?",
                 params![user_id.to_string()],
-                |row| row.get(0),
+                |row| row.get::<_, Option<String>>(0),
             )
-            .optional()?;
+            .optional()?
+            .flatten();
         Ok(namespace)
     }
 
@@ -776,7 +777,8 @@ mod tests {
 
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer mytoken123".parse().unwrap());
-        assert!(svc.authenticate(&headers).is_ok());
+        let user_id = svc.authenticate(&headers).unwrap();
+        assert_eq!(svc.get_user_namespace(user_id).unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- read nullable user namespaces correctly
- restore authenticated lock acquisition for static-token and unscoped local users
- add regression coverage for the exact static-token path
- bump the patch release to 0.13.1

## Verified

- 232 tests passed plus every benchmark target
- strict Clippy passed
- clean-tree cargo publish dry-run passed
- fresh self-hosted smoke passed: health, public election, hierarchical lock acquire/status/renew/release

## Why this matters

The public leader-election API was healthy, but the normal self-hosted STATIC_TOKENS setup could return 500 before acquiring a task lock because SQL NULL was decoded as a required string. This patch restores the agent-coordination path promised by the release.