### PR TITLE
ci: run uptime monitor on dedicated self-hosted runner

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -21,9 +21,9 @@ concurrency:
 
 jobs:
   probe:
-    # Blacksmith is not provisioned for this GitHub organization. Use the
-    # GitHub-hosted runner so scheduled probes can actually start.
-    runs-on: ubuntu-latest
+    # Dedicated macOS runner on FeralHogPen. The custom label prevents this
+    # public repository's general CI jobs from executing on the personal host.
+    runs-on: [self-hosted, macOS, ARM64, octostore-monitor]
     outputs:
       status: ${{ steps.eval.outputs.status }}
       summary: ${{ steps.eval.outputs.summary }}


### PR DESCRIPTION
Uses the dedicated `FeralHogPen-octostore-monitor` macOS ARM64 runner for the scheduled uptime probe. The custom `octostore-monitor` label limits this personal host to the monitor job; general CI stays on GitHub-hosted runners.

Validated YAML parsing and `git diff --check`.