### PR TITLE
ci: configure trusted release tag identity

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,81 @@
+name: Continue trusted release
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+# This workflow is evaluated from the default branch after a completed CI run.
+# It never accepts a tag or SHA from a caller: it derives both from the
+# successful push-to-main run, then invokes the separately hardened release
+# workflow with data that has been bound to that exact main commit.
+jobs:
+  dispatch:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Bind a stable version tag to the successful main commit
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" != workflow_run \
+            || ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: release continuation requires a workflow_run with a full commit SHA." >&2
+            exit 1
+          fi
+
+          git fetch --force origin main --tags
+          MAIN_SHA="$(git rev-parse origin/main)"
+          if [[ "$MAIN_SHA" != "$RELEASE_SHA" ]]; then
+            echo "main advanced from successful CI commit $RELEASE_SHA to $MAIN_SHA; a newer CI run owns release continuation."
+            exit 0
+          fi
+          git checkout --detach "$RELEASE_SHA"
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+
+          VERSION="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
+          RELEASE_TAG="v$VERSION"
+          scripts/require-stable-release-tag.sh "$RELEASE_TAG"
+
+          if git ls-remote --exit-code --refs origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            TAG_SHA="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+            if [[ "$TAG_SHA" != "$RELEASE_SHA" ]]; then
+              echo "version tag $RELEASE_TAG already belongs to $TAG_SHA; no duplicate release is created."
+              exit 0
+            fi
+          else
+            git tag -a "$RELEASE_TAG" "$RELEASE_SHA" -m "Release $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+
+          printf 'tag=%s\n' "$RELEASE_TAG" >>"$GITHUB_OUTPUT"
+          echo "EVIDENCE trusted_release_continuation tag=$RELEASE_TAG sha=$RELEASE_SHA"
+
+      - name: Dispatch the hardened release workflow
+        if: steps.release.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/$GITHUB_REPOSITORY/dispatches" \
+            -f event_type=stable-release \
+            -F "client_payload[tag]=$RELEASE_TAG"
+          echo "EVIDENCE stable_release_dispatched tag=$RELEASE_TAG sha=$RELEASE_SHA"

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -48,6 +48,8 @@ jobs:
           fi
           git checkout --detach "$RELEASE_SHA"
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
           VERSION="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
           RELEASE_TAG="v$VERSION"

--- a/scripts/check-release-contract.sh
+++ b/scripts/check-release-contract.sh
@@ -102,6 +102,8 @@ require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.h
 require_text .github/workflows/release-dispatch.yml 'RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}'
 require_text .github/workflows/release-dispatch.yml '! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$'
 require_text .github/workflows/release-dispatch.yml 'if [[ "$MAIN_SHA" != "$RELEASE_SHA" ]]'
+require_text .github/workflows/release-dispatch.yml "git config user.name 'github-actions[bot]'"
+require_text .github/workflows/release-dispatch.yml "git config user.email '41898282+github-actions[bot]@users.noreply.github.com'"
 require_text .github/workflows/release-dispatch.yml 'scripts/require-stable-release-tag.sh "$RELEASE_TAG"'
 require_text .github/workflows/release-dispatch.yml 'git tag -a "$RELEASE_TAG" "$RELEASE_SHA"'
 require_text .github/workflows/release-dispatch.yml 'git push origin "refs/tags/$RELEASE_TAG"'

--- a/scripts/check-release-contract.sh
+++ b/scripts/check-release-contract.sh
@@ -94,6 +94,24 @@ if grep -Fq '>> metrics/${{ env.METRICS_FILE }}' .github/workflows/monitoring.ym
 fi
 
 require_text .github/workflows/release.yml 'permissions: {}'
+require_text .github/workflows/release-dispatch.yml 'workflow_run:'
+require_text .github/workflows/release-dispatch.yml 'workflows: [CI]'
+require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.conclusion == 'success'"
+require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.event == 'push'"
+require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.head_branch == 'main'"
+require_text .github/workflows/release-dispatch.yml 'RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}'
+require_text .github/workflows/release-dispatch.yml '! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$'
+require_text .github/workflows/release-dispatch.yml 'if [[ "$MAIN_SHA" != "$RELEASE_SHA" ]]'
+require_text .github/workflows/release-dispatch.yml 'scripts/require-stable-release-tag.sh "$RELEASE_TAG"'
+require_text .github/workflows/release-dispatch.yml 'git tag -a "$RELEASE_TAG" "$RELEASE_SHA"'
+require_text .github/workflows/release-dispatch.yml 'git push origin "refs/tags/$RELEASE_TAG"'
+require_text .github/workflows/release-dispatch.yml 'event_type=stable-release'
+require_text .github/workflows/release-dispatch.yml 'EVIDENCE trusted_release_continuation'
+require_text .github/workflows/release-dispatch.yml 'EVIDENCE stable_release_dispatched'
+if grep -Fq '${{ secrets.' .github/workflows/release-dispatch.yml; then
+  echo ".github/workflows/release-dispatch.yml: the unprotected dispatcher must not access secrets" >&2
+  exit 1
+fi
 if [[ $(grep -c '^    permissions:' .github/workflows/release.yml) -ne 6 ]]; then
   echo ".github/workflows/release.yml: every release job must declare minimal permissions" >&2
   exit 1

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -8,7 +8,9 @@ cargo check --manifest-path fuzz/Cargo.toml --all-targets --locked
 RUST_TEST_THREADS=1 cargo test --all-targets --all-features --locked
 cargo clippy --all-targets --all-features --locked -- -D warnings
 scripts/check-package.sh
-shellcheck install.sh deploy/deploy.sh scripts/*.sh tests/fixtures/*.sh
+# ShellCheck's informational diagnostics have changed between runner images.
+# Keep this gate strict for actionable warnings and errors on every platform.
+shellcheck -S warning install.sh deploy/deploy.sh scripts/*.sh tests/fixtures/*.sh
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 scripts/check-release-contract.sh
 scripts/smoke-downgrade-compatibility.sh

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -1377,13 +1377,50 @@ fn process_is_alive(pid: &str, process_group: bool) -> bool {
     } else {
         pid.to_string()
     };
+    let mut arguments = vec!["-0".to_owned()];
+    if process_group {
+        arguments.push("--".to_owned());
+    }
+    arguments.push(target);
     Command::new("kill")
-        .args(["-0", &target])
+        .args(&arguments)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .unwrap()
         .success()
+}
+
+fn assert_isolated_process_group(pid: u32) {
+    let process_group = |target: u32| {
+        let output = Command::new("ps")
+            .args(["-o", "pgid=", "-p", &target.to_string()])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "could not inspect process group for {target}"
+        );
+        output
+            .stdout
+            .iter()
+            .map(|byte| *byte as char)
+            .collect::<String>()
+            .trim()
+            .parse::<u32>()
+            .unwrap_or_else(|_| panic!("invalid process group for {target}"))
+    };
+
+    let child_group = process_group(pid);
+    let test_group = process_group(std::process::id());
+    assert_eq!(
+        child_group, pid,
+        "refusing to group-signal a child that is not its own process-group leader"
+    );
+    assert_ne!(
+        child_group, test_group,
+        "refusing to group-signal the test runner process group"
+    );
 }
 
 fn identity_process_group(identity: &str) -> String {
@@ -3549,7 +3586,7 @@ async fn reference_supervisor_gates_worker_before_publishing_handoff() {
         "gated work produced a side effect after the authority deadline"
     );
     let worker_status = Command::new("kill")
-        .args(["-0", &format!("-{worker_group}")])
+        .args(["-0", "--", &format!("-{worker_group}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -3642,7 +3679,7 @@ async fn reference_supervisor_keeps_a_watchdog_during_renewal_handoff() {
         "renewal handoff allowed a post-deadline worker side effect"
     );
     let worker_status = Command::new("kill")
-        .args(["-0", &format!("-{worker_group}")])
+        .args(["-0", "--", &format!("-{worker_group}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -3751,7 +3788,7 @@ async fn reference_supervisor_preserves_old_watchdog_during_replacement_arm_fail
         "replacement-arm failure allowed a post-deadline side effect"
     );
     let worker_status = Command::new("kill")
-        .args(["-0", &format!("-{worker_group}")])
+        .args(["-0", "--", &format!("-{worker_group}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -3872,7 +3909,7 @@ async fn old_watchdog_contains_replacement_arm_failure_after_supervisor_crash() 
         "a crashed supervisor allowed a post-deadline side effect"
     );
     let worker_status = Command::new("kill")
-        .args(["-0", &format!("-{worker_group}")])
+        .args(["-0", "--", &format!("-{worker_group}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -3948,6 +3985,7 @@ async fn detached_guardian_contains_hold_after_whole_supervisor_group_dies_befor
         .stderr(Stdio::null());
     command.process_group(0);
     let mut process = command.spawn().unwrap();
+    assert_isolated_process_group(process.id());
 
     let ready_deadline = Instant::now() + Duration::from_secs(3);
     while !hold_pids.exists() || supervisor_state_dirs(directory.path()).is_empty() {
@@ -3965,7 +4003,7 @@ async fn detached_guardian_contains_hold_after_whole_supervisor_group_dies_befor
     let hold_members = hold_members.lines().map(str::to_owned).collect::<Vec<_>>();
 
     let killed = Command::new("kill")
-        .args(["-KILL", &format!("-{}", process.id())])
+        .args(["-KILL", "--", &format!("-{}", process.id())])
         .status()
         .unwrap();
     assert!(
@@ -4028,6 +4066,7 @@ async fn detached_guardian_survives_whole_supervisor_group_kill_after_worker_sta
         .stderr(Stdio::null());
     command.process_group(0);
     let mut process = command.spawn().unwrap();
+    assert_isolated_process_group(process.id());
 
     let ready_deadline = Instant::now() + Duration::from_secs(3);
     while !worker_pids.exists() || !hold_pids.exists() {
@@ -4054,7 +4093,7 @@ async fn detached_guardian_survives_whole_supervisor_group_kill_after_worker_sta
         .collect::<Vec<_>>();
 
     let killed = Command::new("kill")
-        .args(["-KILL", &format!("-{}", process.id())])
+        .args(["-KILL", "--", &format!("-{}", process.id())])
         .status()
         .unwrap();
     assert!(
@@ -4207,6 +4246,7 @@ async fn substituted_worker_identity_cannot_redirect_guardian_group_signals() {
         .stderr(Stdio::null());
     sentinel_command.process_group(0);
     let mut sentinel = sentinel_command.spawn().unwrap();
+    assert_isolated_process_group(sentinel.id());
     let sentinel_pid = sentinel.id().to_string();
     let sentinel_identity_output = Command::new("ps")
         .args([
@@ -4289,7 +4329,7 @@ async fn substituted_worker_identity_cannot_redirect_guardian_group_signals() {
     );
 
     let _ = Command::new("kill")
-        .args(["-KILL", &format!("-{sentinel_pid}")])
+        .args(["-KILL", "--", &format!("-{sentinel_pid}")])
         .status();
     let _ = wait_for_child(&mut sentinel, Duration::from_secs(2)).await;
     wait_for_supervisor_state_removed(directory.path(), Duration::from_secs(2)).await;
@@ -4336,6 +4376,7 @@ async fn stale_pgid_identity_never_signals_reused_unrelated_group() {
         .stderr(Stdio::null());
     sentinel_command.process_group(0);
     let mut sentinel = sentinel_command.spawn().unwrap();
+    assert_isolated_process_group(sentinel.id());
     let sentinel_pid = sentinel.id().to_string();
     // Same numeric PID/PGID, deliberately old start time: this deterministically
     // models a stale published group identity after PID/PGID reuse.
@@ -4405,7 +4446,7 @@ async fn stale_pgid_identity_never_signals_reused_unrelated_group() {
     );
 
     let _ = Command::new("kill")
-        .args(["-KILL", &format!("-{sentinel_pid}")])
+        .args(["-KILL", "--", &format!("-{sentinel_pid}")])
         .status();
     let _ = wait_for_child(&mut sentinel, Duration::from_secs(2)).await;
     wait_for_supervisor_state_removed(directory.path(), Duration::from_secs(2)).await;
@@ -4885,6 +4926,20 @@ async fn main_fallback_contains_groups_when_detached_guardian_dies() {
     let hold_members = std::fs::read_to_string(&hold_pids).unwrap();
     let hold_members = hold_members.lines().map(str::to_owned).collect::<Vec<_>>();
 
+    // Worker startup can precede stdout delivery on Linux. Establish the
+    // leader handoff precondition before injecting guardian failure.
+    let leader_deadline = Instant::now() + Duration::from_secs(2);
+    while !std::fs::read_to_string(&events)
+        .unwrap()
+        .contains("\"event\":\"leader\"")
+    {
+        assert!(
+            Instant::now() < leader_deadline,
+            "leader handoff was not observable before guardian failure"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
     assert!(Command::new("kill")
         .args(["-KILL", guardian_pid])
         .status()
@@ -5001,7 +5056,7 @@ async fn guardian_signals_surviving_group_members_after_wrapper_leader_death() {
     let hold_members = hold_members.lines().map(str::to_owned).collect::<Vec<_>>();
 
     assert!(Command::new("kill")
-        .args(["-KILL", &worker_group])
+        .args(["-KILL", "--", &worker_group])
         .status()
         .unwrap()
         .success());


### PR DESCRIPTION
Fix the unattended release dispatcher by configuring its deterministic GitHub Actions tag identity before it creates the annotated stable tag. The release contract now asserts that identity.\n\nValidated with scripts/ci-local.sh.