### PR TITLE
ci: configure trusted release tag identity

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -48,6 +48,8 @@ jobs:
           fi
           git checkout --detach "$RELEASE_SHA"
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
           VERSION="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
           RELEASE_TAG="v$VERSION"

--- a/scripts/check-release-contract.sh
+++ b/scripts/check-release-contract.sh
@@ -102,6 +102,8 @@ require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.h
 require_text .github/workflows/release-dispatch.yml 'RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}'
 require_text .github/workflows/release-dispatch.yml '! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$'
 require_text .github/workflows/release-dispatch.yml 'if [[ "$MAIN_SHA" != "$RELEASE_SHA" ]]'
+require_text .github/workflows/release-dispatch.yml "git config user.name 'github-actions[bot]'"
+require_text .github/workflows/release-dispatch.yml "git config user.email '41898282+github-actions[bot]@users.noreply.github.com'"
 require_text .github/workflows/release-dispatch.yml 'scripts/require-stable-release-tag.sh "$RELEASE_TAG"'
 require_text .github/workflows/release-dispatch.yml 'git tag -a "$RELEASE_TAG" "$RELEASE_SHA"'
 require_text .github/workflows/release-dispatch.yml 'git push origin "refs/tags/$RELEASE_TAG"'


### PR DESCRIPTION
Fix the unattended release dispatcher by configuring its deterministic GitHub Actions tag identity before it creates the annotated stable tag. The release contract now asserts that identity.\n\nValidated with scripts/ci-local.sh.