### PR TITLE
ci: configure trusted release tag identity

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,81 @@
+name: Continue trusted release
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+# This workflow is evaluated from the default branch after a completed CI run.
+# It never accepts a tag or SHA from a caller: it derives both from the
+# successful push-to-main run, then invokes the separately hardened release
+# workflow with data that has been bound to that exact main commit.
+jobs:
+  dispatch:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Bind a stable version tag to the successful main commit
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" != workflow_run \
+            || ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: release continuation requires a workflow_run with a full commit SHA." >&2
+            exit 1
+          fi
+
+          git fetch --force origin main --tags
+          MAIN_SHA="$(git rev-parse origin/main)"
+          if [[ "$MAIN_SHA" != "$RELEASE_SHA" ]]; then
+            echo "main advanced from successful CI commit $RELEASE_SHA to $MAIN_SHA; a newer CI run owns release continuation."
+            exit 0
+          fi
+          git checkout --detach "$RELEASE_SHA"
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+
+          VERSION="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
+          RELEASE_TAG="v$VERSION"
+          scripts/require-stable-release-tag.sh "$RELEASE_TAG"
+
+          if git ls-remote --exit-code --refs origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            TAG_SHA="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+            if [[ "$TAG_SHA" != "$RELEASE_SHA" ]]; then
+              echo "version tag $RELEASE_TAG already belongs to $TAG_SHA; no duplicate release is created."
+              exit 0
+            fi
+          else
+            git tag -a "$RELEASE_TAG" "$RELEASE_SHA" -m "Release $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+
+          printf 'tag=%s\n' "$RELEASE_TAG" >>"$GITHUB_OUTPUT"
+          echo "EVIDENCE trusted_release_continuation tag=$RELEASE_TAG sha=$RELEASE_SHA"
+
+      - name: Dispatch the hardened release workflow
+        if: steps.release.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/$GITHUB_REPOSITORY/dispatches" \
+            -f event_type=stable-release \
+            -F "client_payload[tag]=$RELEASE_TAG"
+          echo "EVIDENCE stable_release_dispatched tag=$RELEASE_TAG sha=$RELEASE_SHA"

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -48,6 +48,8 @@ jobs:
           fi
           git checkout --detach "$RELEASE_SHA"
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
           VERSION="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
           RELEASE_TAG="v$VERSION"

--- a/scripts/check-release-contract.sh
+++ b/scripts/check-release-contract.sh
@@ -102,6 +102,8 @@ require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.h
 require_text .github/workflows/release-dispatch.yml 'RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}'
 require_text .github/workflows/release-dispatch.yml '! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$'
 require_text .github/workflows/release-dispatch.yml 'if [[ "$MAIN_SHA" != "$RELEASE_SHA" ]]'
+require_text .github/workflows/release-dispatch.yml "git config user.name 'github-actions[bot]'"
+require_text .github/workflows/release-dispatch.yml "git config user.email '41898282+github-actions[bot]@users.noreply.github.com'"
 require_text .github/workflows/release-dispatch.yml 'scripts/require-stable-release-tag.sh "$RELEASE_TAG"'
 require_text .github/workflows/release-dispatch.yml 'git tag -a "$RELEASE_TAG" "$RELEASE_SHA"'
 require_text .github/workflows/release-dispatch.yml 'git push origin "refs/tags/$RELEASE_TAG"'

--- a/scripts/check-release-contract.sh
+++ b/scripts/check-release-contract.sh
@@ -94,6 +94,24 @@ if grep -Fq '>> metrics/${{ env.METRICS_FILE }}' .github/workflows/monitoring.ym
 fi
 
 require_text .github/workflows/release.yml 'permissions: {}'
+require_text .github/workflows/release-dispatch.yml 'workflow_run:'
+require_text .github/workflows/release-dispatch.yml 'workflows: [CI]'
+require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.conclusion == 'success'"
+require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.event == 'push'"
+require_text .github/workflows/release-dispatch.yml "github.event.workflow_run.head_branch == 'main'"
+require_text .github/workflows/release-dispatch.yml 'RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}'
+require_text .github/workflows/release-dispatch.yml '! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$'
+require_text .github/workflows/release-dispatch.yml 'if [[ "$MAIN_SHA" != "$RELEASE_SHA" ]]'
+require_text .github/workflows/release-dispatch.yml 'scripts/require-stable-release-tag.sh "$RELEASE_TAG"'
+require_text .github/workflows/release-dispatch.yml 'git tag -a "$RELEASE_TAG" "$RELEASE_SHA"'
+require_text .github/workflows/release-dispatch.yml 'git push origin "refs/tags/$RELEASE_TAG"'
+require_text .github/workflows/release-dispatch.yml 'event_type=stable-release'
+require_text .github/workflows/release-dispatch.yml 'EVIDENCE trusted_release_continuation'
+require_text .github/workflows/release-dispatch.yml 'EVIDENCE stable_release_dispatched'
+if grep -Fq '${{ secrets.' .github/workflows/release-dispatch.yml; then
+  echo ".github/workflows/release-dispatch.yml: the unprotected dispatcher must not access secrets" >&2
+  exit 1
+fi
 if [[ $(grep -c '^    permissions:' .github/workflows/release.yml) -ne 6 ]]; then
   echo ".github/workflows/release.yml: every release job must declare minimal permissions" >&2
   exit 1

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -8,7 +8,9 @@ cargo check --manifest-path fuzz/Cargo.toml --all-targets --locked
 RUST_TEST_THREADS=1 cargo test --all-targets --all-features --locked
 cargo clippy --all-targets --all-features --locked -- -D warnings
 scripts/check-package.sh
-shellcheck install.sh deploy/deploy.sh scripts/*.sh tests/fixtures/*.sh
+# ShellCheck's informational diagnostics have changed between runner images.
+# Keep this gate strict for actionable warnings and errors on every platform.
+shellcheck -S warning install.sh deploy/deploy.sh scripts/*.sh tests/fixtures/*.sh
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 scripts/check-release-contract.sh
 scripts/smoke-downgrade-compatibility.sh

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -1377,13 +1377,50 @@ fn process_is_alive(pid: &str, process_group: bool) -> bool {
     } else {
         pid.to_string()
     };
+    let mut arguments = vec!["-0".to_owned()];
+    if process_group {
+        arguments.push("--".to_owned());
+    }
+    arguments.push(target);
     Command::new("kill")
-        .args(["-0", &target])
+        .args(&arguments)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .unwrap()
         .success()
+}
+
+fn assert_isolated_process_group(pid: u32) {
+    let process_group = |target: u32| {
+        let output = Command::new("ps")
+            .args(["-o", "pgid=", "-p", &target.to_string()])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "could not inspect process group for {target}"
+        );
+        output
+            .stdout
+            .iter()
+            .map(|byte| *byte as char)
+            .collect::<String>()
+            .trim()
+            .parse::<u32>()
+            .unwrap_or_else(|_| panic!("invalid process group for {target}"))
+    };
+
+    let child_group = process_group(pid);
+    let test_group = process_group(std::process::id());
+    assert_eq!(
+        child_group, pid,
+        "refusing to group-signal a child that is not its own process-group leader"
+    );
+    assert_ne!(
+        child_group, test_group,
+        "refusing to group-signal the test runner process group"
+    );
 }
 
 fn identity_process_group(identity: &str) -> String {
@@ -3549,7 +3586,7 @@ async fn reference_supervisor_gates_worker_before_publishing_handoff() {
         "gated work produced a side effect after the authority deadline"
     );
     let worker_status = Command::new("kill")
-        .args(["-0", &format!("-{worker_group}")])
+        .args(["-0", "--", &format!("-{worker_group}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -3642,7 +3679,7 @@ async fn reference_supervisor_keeps_a_watchdog_during_renewal_handoff() {
         "renewal handoff allowed a post-deadline worker side effect"
     );
     let worker_status = Command::new("kill")
-        .args(["-0", &format!("-{worker_group}")])
+        .args(["-0", "--", &format!("-{worker_group}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -3751,7 +3788,7 @@ async fn reference_supervisor_preserves_old_watchdog_during_replacement_arm_fail
         "replacement-arm failure allowed a post-deadline side effect"
     );
     let worker_status = Command::new("kill")
-        .args(["-0", &format!("-{worker_group}")])
+        .args(["-0", "--", &format!("-{worker_group}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -3872,7 +3909,7 @@ async fn old_watchdog_contains_replacement_arm_failure_after_supervisor_crash() 
         "a crashed supervisor allowed a post-deadline side effect"
     );
     let worker_status = Command::new("kill")
-        .args(["-0", &format!("-{worker_group}")])
+        .args(["-0", "--", &format!("-{worker_group}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -3948,6 +3985,7 @@ async fn detached_guardian_contains_hold_after_whole_supervisor_group_dies_befor
         .stderr(Stdio::null());
     command.process_group(0);
     let mut process = command.spawn().unwrap();
+    assert_isolated_process_group(process.id());
 
     let ready_deadline = Instant::now() + Duration::from_secs(3);
     while !hold_pids.exists() || supervisor_state_dirs(directory.path()).is_empty() {
@@ -3965,7 +4003,7 @@ async fn detached_guardian_contains_hold_after_whole_supervisor_group_dies_befor
     let hold_members = hold_members.lines().map(str::to_owned).collect::<Vec<_>>();
 
     let killed = Command::new("kill")
-        .args(["-KILL", &format!("-{}", process.id())])
+        .args(["-KILL", "--", &format!("-{}", process.id())])
         .status()
         .unwrap();
     assert!(
@@ -4028,6 +4066,7 @@ async fn detached_guardian_survives_whole_supervisor_group_kill_after_worker_sta
         .stderr(Stdio::null());
     command.process_group(0);
     let mut process = command.spawn().unwrap();
+    assert_isolated_process_group(process.id());
 
     let ready_deadline = Instant::now() + Duration::from_secs(3);
     while !worker_pids.exists() || !hold_pids.exists() {
@@ -4054,7 +4093,7 @@ async fn detached_guardian_survives_whole_supervisor_group_kill_after_worker_sta
         .collect::<Vec<_>>();
 
     let killed = Command::new("kill")
-        .args(["-KILL", &format!("-{}", process.id())])
+        .args(["-KILL", "--", &format!("-{}", process.id())])
         .status()
         .unwrap();
     assert!(
@@ -4207,6 +4246,7 @@ async fn substituted_worker_identity_cannot_redirect_guardian_group_signals() {
         .stderr(Stdio::null());
     sentinel_command.process_group(0);
     let mut sentinel = sentinel_command.spawn().unwrap();
+    assert_isolated_process_group(sentinel.id());
     let sentinel_pid = sentinel.id().to_string();
     let sentinel_identity_output = Command::new("ps")
         .args([
@@ -4289,7 +4329,7 @@ async fn substituted_worker_identity_cannot_redirect_guardian_group_signals() {
     );
 
     let _ = Command::new("kill")
-        .args(["-KILL", &format!("-{sentinel_pid}")])
+        .args(["-KILL", "--", &format!("-{sentinel_pid}")])
         .status();
     let _ = wait_for_child(&mut sentinel, Duration::from_secs(2)).await;
     wait_for_supervisor_state_removed(directory.path(), Duration::from_secs(2)).await;
@@ -4336,6 +4376,7 @@ async fn stale_pgid_identity_never_signals_reused_unrelated_group() {
         .stderr(Stdio::null());
     sentinel_command.process_group(0);
     let mut sentinel = sentinel_command.spawn().unwrap();
+    assert_isolated_process_group(sentinel.id());
     let sentinel_pid = sentinel.id().to_string();
     // Same numeric PID/PGID, deliberately old start time: this deterministically
     // models a stale published group identity after PID/PGID reuse.
@@ -4405,7 +4446,7 @@ async fn stale_pgid_identity_never_signals_reused_unrelated_group() {
     );
 
     let _ = Command::new("kill")
-        .args(["-KILL", &format!("-{sentinel_pid}")])
+        .args(["-KILL", "--", &format!("-{sentinel_pid}")])
         .status();
     let _ = wait_for_child(&mut sentinel, Duration::from_secs(2)).await;
     wait_for_supervisor_state_removed(directory.path(), Duration::from_secs(2)).await;
@@ -4885,6 +4926,20 @@ async fn main_fallback_contains_groups_when_detached_guardian_dies() {
     let hold_members = std::fs::read_to_string(&hold_pids).unwrap();
     let hold_members = hold_members.lines().map(str::to_owned).collect::<Vec<_>>();
 
+    // Worker startup can precede stdout delivery on Linux. Establish the
+    // leader handoff precondition before injecting guardian failure.
+    let leader_deadline = Instant::now() + Duration::from_secs(2);
+    while !std::fs::read_to_string(&events)
+        .unwrap()
+        .contains("\"event\":\"leader\"")
+    {
+        assert!(
+            Instant::now() < leader_deadline,
+            "leader handoff was not observable before guardian failure"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
     assert!(Command::new("kill")
         .args(["-KILL", guardian_pid])
         .status()
@@ -5001,7 +5056,7 @@ async fn guardian_signals_surviving_group_members_after_wrapper_leader_death() {
     let hold_members = hold_members.lines().map(str::to_owned).collect::<Vec<_>>();
 
     assert!(Command::new("kill")
-        .args(["-KILL", &worker_group])
+        .args(["-KILL", "--", &worker_group])
         .status()
         .unwrap()
         .success());


### PR DESCRIPTION
Fix the unattended release dispatcher by configuring its deterministic GitHub Actions tag identity before it creates the annotated stable tag. The release contract now asserts that identity.\n\nValidated with 
running 217 tests
test auth::tests::admin_key_is_not_accepted_as_a_bearer_token ... ok
test auth::tests::callback_location_contains_only_one_time_handoff_code ... ok
test auth::tests::checked_static_token_seeding_rejects_an_unreadable_configured_file ... ok
test auth::tests::legacy_migration_and_mode_switches_activate_only_proven_identity_sources ... ok
test auth::tests::oauth_login_promotes_only_a_proven_bootstrap_identity_and_rotates_its_token ... ok
test auth::tests::oauth_login_rejects_ids_outside_sqlites_supported_range ... ok
test auth::tests::oauth_login_updates_the_exact_identity_but_rejects_same_name_id_conflicts ... ok
test auth::tests::oauth_state_cookie_parser_finds_the_host_only_cookie ... ok
test auth::tests::oauth_state_is_cookie_bound_single_use_and_rejects_replay ... ok
test auth::tests::oauth_state_rejects_missing_cookie_and_expiry ... ok
test auth::tests::static_token_seeding_is_all_or_nothing_across_late_conflicts_and_restart ... ok
test auth::tests::static_token_seeding_rejects_legacy_hash_and_multirow_matches ... ok
test auth::tests::synthetic_admin_never_becomes_a_bearer_user_before_or_after_restart ... ok
test auth::tests::test_auth_service_new_memory ... ok
test auth::tests::test_auth_service_rejects_legacy_case_ambiguous_identities_at_startup ... ok
test auth::tests::test_authenticate_invalid_token ... ok
test auth::tests::test_authenticate_missing_header ... ok
test auth::tests::test_authenticate_valid_token ... ok
test auth::tests::test_fencing_counter ... ok
test auth::tests::test_github_auth_url_with_creds ... ok
test auth::tests::test_github_auth_url_without_creds ... ok
test auth::tests::test_local_id_different_users ... ok
test auth::tests::test_local_id_high_bit_set ... ok
test auth::tests::test_local_id_stable ... ok
test auth::tests::test_parse_token_list_bare ... ok
test auth::tests::test_parse_token_list_file_format ... ok
test auth::tests::test_parse_token_list_user_token ... ok
test auth::tests::test_parse_token_list_whitespace ... ok
test auth::tests::test_register_local_user ... ok
test auth::tests::test_register_local_user_rejects_a_static_user_collision ... ok
test auth::tests::test_register_local_user_rejects_bad_chars ... ok
test auth::tests::test_register_local_user_rejects_bad_namespace_as_invalid_input ... ok
test auth::tests::test_register_local_user_rejects_empty ... ok
test auth::tests::test_register_local_user_rejects_mixed_case_and_legacy_oauth_collisions ... ok
test auth::tests::test_register_local_user_rejects_repeated_registration_without_returning_a_token ... ok
test auth::tests::test_seed_static_tokens ... ok
test auth::tests::test_seed_static_tokens_from_file ... ok
test cli::tests::authority_observation_timestamps_before_sampling_the_remaining_budget ... ok
test cli::tests::cleartext_credentials_are_limited_to_loopback_without_override ... ok
test cli::tests::cli_contract_parses_all_leaf_commands_and_bare_server ... ok
test cli::tests::duration_parser_is_strict_and_bounded ... ok
test cli::tests::lifecycle_event_schema_never_contains_capabilities ... ok
test cli::tests::one_transport_chunk_can_supply_multiple_bounded_sse_frames ... ok
test cli::tests::oversized_sse_append_is_rejected_before_pending_buffer_mutation ... ok
test cli::tests::server_retry_guidance_is_never_shortened_by_local_backoff_cap ... ok
test cli::tests::session_confirmation_has_an_independent_continuous_deadline ... ok
test cli::tests::sse_frame_parser_handles_lf_and_crlf ... ok
test cli::tests::sub_millisecond_authority_budget_fails_closed_with_lost_exit ... ok
test cli::tests::suspend_inclusive_clock_expires_authority_when_scheduler_clock_lags ... ok
test cli::tests::terminal_output_escapes_control_characters ... ok
test cli::tests::timed_out_leader_response_is_resigned_before_timeout_is_reported ... ok
test cli::tests::timing_jitter_never_violates_its_direction_or_ten_percent_bound ... ok
test cli::tests::token_file_rejects_symlinks_without_a_check_then_open_race ... ok
test cli::tests::token_file_requires_owner_only_permissions ... ok
test cli::tests::watch_json_uses_a_versioned_sequenced_snapshot_envelope ... ok
test config::tests::test_config_defaults ... ok
test config::tests::test_config_github_disabled_when_missing ... ok
test config::tests::test_config_github_enabled ... ok
test config::tests::test_config_rejects_admin_key_collision_from_static_token_file ... ok
test config::tests::test_config_rejects_admin_key_collision_with_static_bearer ... ok
test config::tests::test_config_rejects_empty_explicit_security_values ... ok
test config::tests::test_config_rejects_malformed_public_elections_boolean ... ok
test config::tests::test_config_rejects_malformed_static_tokens_file ... ok
test config::tests::test_config_rejects_partial_github_credentials ... ok
test config::tests::test_config_rejects_unreadable_static_tokens_file ... ok
test config::tests::test_config_rejects_zero_or_invalid_security_limits ... ok
test config::tests::test_config_requires_github_oauth_for_admin_username ... ok
test config::tests::test_config_static_tokens ... ok
test config::tests::test_hosted_oauth_binds_authenticated_locks_to_the_hosted_dashboard ... ok
test config::tests::test_local_registration_rejects_other_identity_sources ... ok
test config::tests::test_local_registration_requires_an_explicit_loopback_only_configuration ... ok
test config::tests::test_oauth_urls_fail_closed_on_unsafe_or_ambiguous_authorities ... ok
test config::tests::test_public_election_config ... ok
test config::tests::test_self_hosted_oauth_binds_callback_dashboard_and_cors_origin ... ok
test config::tests::test_self_hosted_oauth_requires_an_explicit_dashboard ... ok
test elections::tests::accepts_metadata_at_the_documented_limit ... ok
test elections::tests::admission_pressure_does_not_strand_the_current_leader ... ok
test elections::tests::admission_rate_limit_returns_retry_after ... ok
test elections::tests::campaign_renew_resign_and_re_elect ... ok
test elections::tests::capability_round_trip ... ok
test elections::tests::create_room_requires_no_authentication ... ok
test elections::tests::direct_clients_cannot_spoof_the_cloudflare_bucket ... ok
test elections::tests::invalid_leader_token_cannot_mutate_election ... ok
test elections::tests::public_election_limit_applies_across_rooms ... ok
test elections::tests::rejects_candidate_characters_outside_the_openapi_pattern ... ok
test elections::tests::stale_capability_responses_match_the_openapi_contract ... ok
test elections::tests::watch_emits_vacant_after_expiry_cleanup ... ok
test elections::tests::watch_enforces_limits_releases_permits_and_has_bounded_lifetime ... ok
test elections::tests::watch_starts_with_snapshot_and_reconciles_state_transitions ... ok
test error::tests::internal_errors_do_not_leak_diagnostics ... ok
test error::tests::rate_limit_guidance_agrees_across_header_and_body ... ok
test error::tests::test_database_error_conversion ... ok
test error::tests::test_error_conversions ... ok
test error::tests::test_error_display ... ok
test error::tests::test_error_into_response ... ok
test error::tests::test_result_type_alias ... ok
test locks::tests::acquire_rejects_lock_delay_above_documented_maximum ... ok
test locks::tests::delayed_acquire_and_stale_lease_have_machine_guidance ... ok
test locks::tests::durable_session_correlated_lock_remains_in_user_quota_after_teardown ... ok
test locks::tests::durable_session_correlated_lock_remains_user_managed_after_teardown ... ok
test locks::tests::expired_lock_enters_delay_even_before_periodic_cleanup ... ok
test locks::tests::lagged_lock_watch_closes_instead_of_hiding_missed_events ... ok
test locks::tests::lock_watch_never_exposes_same_token_session_or_lease_capabilities ... ok
test locks::tests::public_holder_pseudonym_cannot_inspect_or_terminate_same_token_session ... ok
test locks::tests::same_holder_reacquire_at_limit_renews_and_uses_actual_expiry_guidance ... ok
test locks::tests::same_holder_reacquire_returns_the_persisted_metadata_snapshot ... ok
test locks::tests::scoped_list_without_prefix_defaults_to_caller_namespace ... ok
test locks::tests::session_status_is_indistinguishable_across_users ... ok
test locks::tests::test_acl_blocks_non_members ... ok
test locks::tests::test_acl_normalization_preserves_token_case_and_normalizes_users ... ok
test locks::tests::test_acl_rejects_too_many_principals ... ok
test locks::tests::test_acl_remains_after_release ... ok
test locks::tests::test_acl_update_requires_holder_or_admin ... ok
test locks::tests::test_acquire_expired_lock ... ok
test locks::tests::test_acquire_held_by_another_user ... ok
test locks::tests::test_acquire_renew_release_lifecycle ... ok
test locks::tests::test_acquire_status_release_roundtrip ... ok
test locks::tests::test_cloned_handlers_share_state ... ok
test locks::tests::test_idempotent_reacquire ... ok
test locks::tests::test_new_handlers_have_no_locks ... ok
test locks::tests::test_release_wrong_lease ... ok
test locks::tests::test_scoped_prefix_query_rejected_outside_namespace ... ok
test locks::tests::test_scoped_token_only_acquires_in_namespace ... ok
test locks::tests::test_token_acl_is_case_sensitive_and_redacted_from_status ... ok
test metrics::tests::test_calculate_percentiles ... ok
test metrics::tests::test_concurrent_metrics_access ... ok
test metrics::tests::test_edge_cases ... ok
test metrics::tests::test_endpoint_from_path ... ok
test metrics::tests::test_endpoint_metrics_concurrent_min_max ... ok
test metrics::tests::test_endpoint_metrics_default ... ok
test metrics::tests::test_endpoint_metrics_histogram_buckets ... ok
test metrics::tests::test_endpoint_metrics_min_max_update ... ok
test metrics::tests::test_endpoint_metrics_record_error ... ok
test metrics::tests::test_endpoint_metrics_record_success ... ok
test metrics::tests::test_endpoint_metrics_snapshot ... ok
test metrics::tests::test_endpoint_metrics_snapshot_empty ... ok
test metrics::tests::test_endpoint_to_json ... ok
test metrics::tests::test_get_memory_usage ... ok
test metrics::tests::test_metrics_new ... ok
test metrics::tests::test_metrics_record_cache_hit ... ok
test metrics::tests::test_metrics_record_lock_operation ... ok
test metrics::tests::test_metrics_record_request ... ok
test metrics::tests::test_metrics_snapshot ... ok
test models::tests::test_acquire_response_tags_correctly ... ok
test models::tests::test_boundary_values ... ok
test models::tests::test_lock_is_expired ... ok
test models::tests::test_validate_lock_name ... ok
test models::tests::test_validate_metadata ... ok
test models::tests::test_validate_ttl ... ok
test rate_limit::tests::limits_each_client_independently ... ok
test rate_limit::tests::shared_clones_enforce_one_budget ... ok
test rate_limit::tests::watch_limiter_enforces_per_client_and_global_bounds ... ok
test sessions::tests::acquire_after_teardown_cleanup_cannot_publish_an_orphan_lock ... ok
test sessions::tests::explicit_teardown_does_not_acknowledge_failed_lock_cleanup ... ok
test sessions::tests::keepalive_write_failure_preserves_memory_and_restart_authority ... ok
test sessions::tests::restart_reconciles_expired_session_ephemeral_locks ... ok
test sessions::tests::runtime_expiry_and_keepalive_retain_retry_state_after_lock_delete_failure ... ok
test sessions::tests::runtime_expiry_retries_until_session_row_deletion_succeeds ... ok
test sessions::tests::session_expiry_releases_only_ephemeral_locks ... ok
test sessions::tests::startup_reconciliation_retries_failed_lock_delete_across_restart ... ok
test sessions::tests::teardown_waits_for_inflight_session_lock_then_removes_it ... ok
test sessions::tests::teardown_waits_for_inflight_session_renewal_then_removes_the_lock ... ok
test sessions::tests::test_create_session ... ok
test sessions::tests::test_create_session_default_ttl ... ok
test sessions::tests::test_create_session_ttl_clamping ... ok
test sessions::tests::test_get_user_sessions ... ok
test sessions::tests::test_keepalive ... ok
test sessions::tests::test_keepalive_nonexistent_session ... ok
test sessions::tests::test_keepalive_wrong_user ... ok
test sessions::tests::test_session_expiry_releases_locks ... ok
test sessions::tests::test_session_persistence ... ok
test sessions::tests::test_terminate_session ... ok
test sessions::tests::test_terminate_wrong_user ... ok
test store::tests::cooling_marker_metadata_alone_never_hides_a_real_lock ... ok
test store::tests::cooling_persistence_failure_rolls_back_lock_deletion ... ok
test store::tests::cooling_sentinel_holder_cannot_be_a_v0132_authenticated_principal ... ok
test store::tests::expired_lock_delay_is_identical_before_and_after_periodic_cleanup ... ok
test store::tests::initial_lock_and_acl_failure_is_atomic_silent_and_restart_safe ... ok
test store::tests::malformed_impossible_cooling_identity_fails_closed_on_restart ... ok
test store::tests::principal_lock_limit_admission_is_atomic_across_user_and_session_holders ... ok
test store::tests::prop_acquired_lock_can_be_released ... ok
test store::tests::prop_fencing_tokens_monotonic ... ok
test store::tests::prop_lock_owner_isolation ... ok
test store::tests::prop_lock_reacquisition_increments_token ... ok
test store::tests::release_and_expiry_cooling_survive_restart ... ok
test store::tests::release_delay_is_revalidated_after_a_stale_early_check ... ok
test store::tests::same_holder_acquire_persists_and_broadcasts_renewal_without_replacing_lease ... ok
test store::tests::session_cleanup_revalidates_snapshot_before_deleting_reacquired_durable_lock ... ok
test store::tests::stale_acl_snapshot_cannot_acquire_against_new_sticky_policy ... ok
test store::tests::stale_former_holder_cannot_overwrite_reacquired_lock_acl ... ok
test store::tests::startup_fails_on_expired_lock_delete_error_and_retries_the_durable_rows ... ok
test store::tests::startup_rejects_a_corrupt_persisted_lock_session_identity ... ok
test store::tests::test_concurrent_acquire_release_with_persistence ... ok
test store::tests::test_concurrent_same_lock_persistence ... ok
test store::tests::test_expired_lock_cannot_be_renewed ... ok
test store::tests::test_expired_locks_not_restored ... ok
test store::tests::test_fencing_counter_restores ... ok
test store::tests::test_lock_acl_survives_restart ... ok
test store::tests::test_lock_store_enables_wal_mode ... ok
test store::tests::test_locks_survive_restart_simulation ... ok
test store::tests::test_metadata_persists ... ok
test store::tests::test_multiple_locks_persist ... ok
test store::tests::test_prefix_acquisition_returns_an_atomic_leader_snapshot ... ok
test store::tests::test_prefix_limit_is_strict_under_concurrent_acquisition ... ok
test store::tests::test_release_removes_from_sqlite ... ok
test store::tests::test_renew_returns_snapshot_even_if_lock_is_immediately_released ... ok
test store::tests::test_stale_expiry_scan_cannot_delete_reacquired_lock ... ok
test store::tests::watch_registry_is_bounded_and_prunes_disconnected_high_cardinality_streams ... ok
test webhooks::tests::failed_webhook_delete_keeps_runtime_and_durable_state_aligned ... ok
test webhooks::tests::malformed_or_unsupported_persisted_events_fail_closed_on_restart ... ok
test webhooks::tests::webhook_delivery_selection_is_tenant_scoped_and_hides_session_capabilities ... ok
test webhooks::tests::webhook_dns_policy_rejects_private_and_mixed_rebinding_answers ... ok
test webhooks::tests::webhook_event_names_are_validated_before_persistence ... ok
test webhooks::tests::webhook_fanout_live_delivery_never_exceeds_global_bound ... ok
test webhooks::tests::webhook_quota_is_atomic_under_concurrent_creation ... ok
test webhooks::tests::webhook_transport_logs_never_include_url_credentials ... ok
test webhooks::tests::webhook_urls_are_parsed_structurally_and_require_https ... ok

test result: ok. 217 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 22.20s


running 240 tests
test auth::tests::admin_key_is_not_accepted_as_a_bearer_token ... ok
test auth::tests::callback_location_contains_only_one_time_handoff_code ... ok
test auth::tests::checked_static_token_seeding_rejects_an_unreadable_configured_file ... ok
test auth::tests::legacy_migration_and_mode_switches_activate_only_proven_identity_sources ... ok
test auth::tests::oauth_login_promotes_only_a_proven_bootstrap_identity_and_rotates_its_token ... ok
test auth::tests::oauth_login_rejects_ids_outside_sqlites_supported_range ... ok
test auth::tests::oauth_login_updates_the_exact_identity_but_rejects_same_name_id_conflicts ... ok
test auth::tests::oauth_state_cookie_parser_finds_the_host_only_cookie ... ok
test auth::tests::oauth_state_is_cookie_bound_single_use_and_rejects_replay ... ok
test auth::tests::oauth_state_rejects_missing_cookie_and_expiry ... ok
test auth::tests::static_token_seeding_is_all_or_nothing_across_late_conflicts_and_restart ... ok
test auth::tests::static_token_seeding_rejects_legacy_hash_and_multirow_matches ... ok
test auth::tests::synthetic_admin_never_becomes_a_bearer_user_before_or_after_restart ... ok
test auth::tests::test_auth_service_new_memory ... ok
test auth::tests::test_auth_service_rejects_legacy_case_ambiguous_identities_at_startup ... ok
test auth::tests::test_authenticate_invalid_token ... ok
test auth::tests::test_authenticate_missing_header ... ok
test auth::tests::test_authenticate_valid_token ... ok
test auth::tests::test_fencing_counter ... ok
test auth::tests::test_github_auth_url_with_creds ... ok
test auth::tests::test_github_auth_url_without_creds ... ok
test auth::tests::test_local_id_different_users ... ok
test auth::tests::test_local_id_high_bit_set ... ok
test auth::tests::test_local_id_stable ... ok
test auth::tests::test_parse_token_list_bare ... ok
test auth::tests::test_parse_token_list_file_format ... ok
test auth::tests::test_parse_token_list_user_token ... ok
test auth::tests::test_parse_token_list_whitespace ... ok
test auth::tests::test_register_local_user ... ok
test auth::tests::test_register_local_user_rejects_a_static_user_collision ... ok
test auth::tests::test_register_local_user_rejects_bad_chars ... ok
test auth::tests::test_register_local_user_rejects_bad_namespace_as_invalid_input ... ok
test auth::tests::test_register_local_user_rejects_empty ... ok
test auth::tests::test_register_local_user_rejects_mixed_case_and_legacy_oauth_collisions ... ok
test auth::tests::test_register_local_user_rejects_repeated_registration_without_returning_a_token ... ok
test auth::tests::test_seed_static_tokens ... ok
test auth::tests::test_seed_static_tokens_from_file ... ok
test cli::tests::authority_observation_timestamps_before_sampling_the_remaining_budget ... ok
test cli::tests::cleartext_credentials_are_limited_to_loopback_without_override ... ok
test cli::tests::cli_contract_parses_all_leaf_commands_and_bare_server ... ok
test cli::tests::duration_parser_is_strict_and_bounded ... ok
test cli::tests::lifecycle_event_schema_never_contains_capabilities ... ok
test cli::tests::one_transport_chunk_can_supply_multiple_bounded_sse_frames ... ok
test cli::tests::oversized_sse_append_is_rejected_before_pending_buffer_mutation ... ok
test cli::tests::server_retry_guidance_is_never_shortened_by_local_backoff_cap ... ok
test cli::tests::session_confirmation_has_an_independent_continuous_deadline ... ok
test cli::tests::sse_frame_parser_handles_lf_and_crlf ... ok
test cli::tests::sub_millisecond_authority_budget_fails_closed_with_lost_exit ... ok
test cli::tests::suspend_inclusive_clock_expires_authority_when_scheduler_clock_lags ... ok
test cli::tests::terminal_output_escapes_control_characters ... ok
test cli::tests::timed_out_leader_response_is_resigned_before_timeout_is_reported ... ok
test cli::tests::timing_jitter_never_violates_its_direction_or_ten_percent_bound ... ok
test cli::tests::token_file_rejects_symlinks_without_a_check_then_open_race ... ok
test cli::tests::token_file_requires_owner_only_permissions ... ok
test cli::tests::watch_json_uses_a_versioned_sequenced_snapshot_envelope ... ok
test config::tests::test_config_defaults ... ok
test config::tests::test_config_github_disabled_when_missing ... ok
test config::tests::test_config_github_enabled ... ok
test config::tests::test_config_rejects_admin_key_collision_from_static_token_file ... ok
test config::tests::test_config_rejects_admin_key_collision_with_static_bearer ... ok
test config::tests::test_config_rejects_empty_explicit_security_values ... ok
test config::tests::test_config_rejects_malformed_public_elections_boolean ... ok
test config::tests::test_config_rejects_malformed_static_tokens_file ... ok
test config::tests::test_config_rejects_partial_github_credentials ... ok
test config::tests::test_config_rejects_unreadable_static_tokens_file ... ok
test config::tests::test_config_rejects_zero_or_invalid_security_limits ... ok
test config::tests::test_config_requires_github_oauth_for_admin_username ... ok
test config::tests::test_config_static_tokens ... ok
test config::tests::test_hosted_oauth_binds_authenticated_locks_to_the_hosted_dashboard ... ok
test config::tests::test_local_registration_rejects_other_identity_sources ... ok
test config::tests::test_local_registration_requires_an_explicit_loopback_only_configuration ... ok
test config::tests::test_oauth_urls_fail_closed_on_unsafe_or_ambiguous_authorities ... ok
test config::tests::test_public_election_config ... ok
test config::tests::test_self_hosted_oauth_binds_callback_dashboard_and_cors_origin ... ok
test config::tests::test_self_hosted_oauth_requires_an_explicit_dashboard ... ok
test elections::tests::accepts_metadata_at_the_documented_limit ... ok
test elections::tests::admission_pressure_does_not_strand_the_current_leader ... ok
test elections::tests::admission_rate_limit_returns_retry_after ... ok
test elections::tests::campaign_renew_resign_and_re_elect ... ok
test elections::tests::capability_round_trip ... ok
test elections::tests::create_room_requires_no_authentication ... ok
test elections::tests::direct_clients_cannot_spoof_the_cloudflare_bucket ... ok
test elections::tests::invalid_leader_token_cannot_mutate_election ... ok
test elections::tests::public_election_limit_applies_across_rooms ... ok
test elections::tests::rejects_candidate_characters_outside_the_openapi_pattern ... ok
test elections::tests::stale_capability_responses_match_the_openapi_contract ... ok
test elections::tests::watch_emits_vacant_after_expiry_cleanup ... ok
test elections::tests::watch_enforces_limits_releases_permits_and_has_bounded_lifetime ... ok
test elections::tests::watch_starts_with_snapshot_and_reconciles_state_transitions ... ok
test error::tests::internal_errors_do_not_leak_diagnostics ... ok
test error::tests::rate_limit_guidance_agrees_across_header_and_body ... ok
test error::tests::test_database_error_conversion ... ok
test error::tests::test_error_conversions ... ok
test error::tests::test_error_display ... ok
test error::tests::test_error_into_response ... ok
test error::tests::test_result_type_alias ... ok
test locks::tests::acquire_rejects_lock_delay_above_documented_maximum ... ok
test locks::tests::delayed_acquire_and_stale_lease_have_machine_guidance ... ok
test locks::tests::durable_session_correlated_lock_remains_in_user_quota_after_teardown ... ok
test locks::tests::durable_session_correlated_lock_remains_user_managed_after_teardown ... ok
test locks::tests::expired_lock_enters_delay_even_before_periodic_cleanup ... ok
test locks::tests::lagged_lock_watch_closes_instead_of_hiding_missed_events ... ok
test locks::tests::lock_watch_never_exposes_same_token_session_or_lease_capabilities ... ok
test locks::tests::public_holder_pseudonym_cannot_inspect_or_terminate_same_token_session ... ok
test locks::tests::same_holder_reacquire_at_limit_renews_and_uses_actual_expiry_guidance ... ok
test locks::tests::same_holder_reacquire_returns_the_persisted_metadata_snapshot ... ok
test locks::tests::scoped_list_without_prefix_defaults_to_caller_namespace ... ok
test locks::tests::session_status_is_indistinguishable_across_users ... ok
test locks::tests::test_acl_blocks_non_members ... ok
test locks::tests::test_acl_normalization_preserves_token_case_and_normalizes_users ... ok
test locks::tests::test_acl_rejects_too_many_principals ... ok
test locks::tests::test_acl_remains_after_release ... ok
test locks::tests::test_acl_update_requires_holder_or_admin ... ok
test locks::tests::test_acquire_expired_lock ... ok
test locks::tests::test_acquire_held_by_another_user ... ok
test locks::tests::test_acquire_renew_release_lifecycle ... ok
test locks::tests::test_acquire_status_release_roundtrip ... ok
test locks::tests::test_cloned_handlers_share_state ... ok
test locks::tests::test_idempotent_reacquire ... ok
test locks::tests::test_new_handlers_have_no_locks ... ok
test locks::tests::test_release_wrong_lease ... ok
test locks::tests::test_scoped_prefix_query_rejected_outside_namespace ... ok
test locks::tests::test_scoped_token_only_acquires_in_namespace ... ok
test locks::tests::test_token_acl_is_case_sensitive_and_redacted_from_status ... ok
test metrics::tests::test_calculate_percentiles ... ok
test metrics::tests::test_concurrent_metrics_access ... ok
test metrics::tests::test_edge_cases ... ok
test metrics::tests::test_endpoint_from_path ... ok
test metrics::tests::test_endpoint_metrics_concurrent_min_max ... ok
test metrics::tests::test_endpoint_metrics_default ... ok
test metrics::tests::test_endpoint_metrics_histogram_buckets ... ok
test metrics::tests::test_endpoint_metrics_min_max_update ... ok
test metrics::tests::test_endpoint_metrics_record_error ... ok
test metrics::tests::test_endpoint_metrics_record_success ... ok
test metrics::tests::test_endpoint_metrics_snapshot ... ok
test metrics::tests::test_endpoint_metrics_snapshot_empty ... ok
test metrics::tests::test_endpoint_to_json ... ok
test metrics::tests::test_get_memory_usage ... ok
test metrics::tests::test_metrics_new ... ok
test metrics::tests::test_metrics_record_cache_hit ... ok
test metrics::tests::test_metrics_record_lock_operation ... ok
test metrics::tests::test_metrics_record_request ... ok
test metrics::tests::test_metrics_snapshot ... ok
test models::tests::test_acquire_response_tags_correctly ... ok
test models::tests::test_boundary_values ... ok
test models::tests::test_lock_is_expired ... ok
test models::tests::test_validate_lock_name ... ok
test models::tests::test_validate_metadata ... ok
test models::tests::test_validate_ttl ... ok
test rate_limit::tests::limits_each_client_independently ... ok
test rate_limit::tests::shared_clones_enforce_one_budget ... ok
test rate_limit::tests::watch_limiter_enforces_per_client_and_global_bounds ... ok
test sessions::tests::acquire_after_teardown_cleanup_cannot_publish_an_orphan_lock ... ok
test sessions::tests::explicit_teardown_does_not_acknowledge_failed_lock_cleanup ... ok
test sessions::tests::keepalive_write_failure_preserves_memory_and_restart_authority ... ok
test sessions::tests::restart_reconciles_expired_session_ephemeral_locks ... ok
test sessions::tests::runtime_expiry_and_keepalive_retain_retry_state_after_lock_delete_failure ... ok
test sessions::tests::runtime_expiry_retries_until_session_row_deletion_succeeds ... ok
test sessions::tests::session_expiry_releases_only_ephemeral_locks ... ok
test sessions::tests::startup_reconciliation_retries_failed_lock_delete_across_restart ... ok
test sessions::tests::teardown_waits_for_inflight_session_lock_then_removes_it ... ok
test sessions::tests::teardown_waits_for_inflight_session_renewal_then_removes_the_lock ... ok
test sessions::tests::test_create_session ... ok
test sessions::tests::test_create_session_default_ttl ... ok
test sessions::tests::test_create_session_ttl_clamping ... ok
test sessions::tests::test_get_user_sessions ... ok
test sessions::tests::test_keepalive ... ok
test sessions::tests::test_keepalive_nonexistent_session ... ok
test sessions::tests::test_keepalive_wrong_user ... ok
test sessions::tests::test_session_expiry_releases_locks ... ok
test sessions::tests::test_session_persistence ... ok
test sessions::tests::test_terminate_session ... ok
test sessions::tests::test_terminate_wrong_user ... ok
test store::tests::cooling_marker_metadata_alone_never_hides_a_real_lock ... ok
test store::tests::cooling_persistence_failure_rolls_back_lock_deletion ... ok
test store::tests::cooling_sentinel_holder_cannot_be_a_v0132_authenticated_principal ... ok
test store::tests::expired_lock_delay_is_identical_before_and_after_periodic_cleanup ... ok
test store::tests::initial_lock_and_acl_failure_is_atomic_silent_and_restart_safe ... ok
test store::tests::malformed_impossible_cooling_identity_fails_closed_on_restart ... ok
test store::tests::principal_lock_limit_admission_is_atomic_across_user_and_session_holders ... ok
test store::tests::prop_acquired_lock_can_be_released ... ok
test store::tests::prop_fencing_tokens_monotonic ... ok
test store::tests::prop_lock_owner_isolation ... ok
test store::tests::prop_lock_reacquisition_increments_token ... ok
test store::tests::release_and_expiry_cooling_survive_restart ... ok
test store::tests::release_delay_is_revalidated_after_a_stale_early_check ... ok
test store::tests::same_holder_acquire_persists_and_broadcasts_renewal_without_replacing_lease ... ok
test store::tests::session_cleanup_revalidates_snapshot_before_deleting_reacquired_durable_lock ... ok
test store::tests::stale_acl_snapshot_cannot_acquire_against_new_sticky_policy ... ok
test store::tests::stale_former_holder_cannot_overwrite_reacquired_lock_acl ... ok
test store::tests::startup_fails_on_expired_lock_delete_error_and_retries_the_durable_rows ... ok
test store::tests::startup_rejects_a_corrupt_persisted_lock_session_identity ... ok
test store::tests::test_concurrent_acquire_release_with_persistence ... ok
test store::tests::test_concurrent_same_lock_persistence ... ok
test store::tests::test_expired_lock_cannot_be_renewed ... ok
test store::tests::test_expired_locks_not_restored ... ok
test store::tests::test_fencing_counter_restores ... ok
test store::tests::test_lock_acl_survives_restart ... ok
test store::tests::test_lock_store_enables_wal_mode ... ok
test store::tests::test_locks_survive_restart_simulation ... ok
test store::tests::test_metadata_persists ... ok
test store::tests::test_multiple_locks_persist ... ok
test store::tests::test_prefix_acquisition_returns_an_atomic_leader_snapshot ... ok
test store::tests::test_prefix_limit_is_strict_under_concurrent_acquisition ... ok
test store::tests::test_release_removes_from_sqlite ... ok
test store::tests::test_renew_returns_snapshot_even_if_lock_is_immediately_released ... ok
test store::tests::test_stale_expiry_scan_cannot_delete_reacquired_lock ... ok
test store::tests::watch_registry_is_bounded_and_prunes_disconnected_high_cardinality_streams ... ok
test tests::admin_username_requires_durable_oauth_identity_provenance ... ok
test tests::metrics_timeseries_rejects_an_unsupported_window_without_relabeling_data ... ok
test tests::openapi_covers_every_public_route_and_stable_error_code ... ok
test tests::self_hosted_oauth_http_flow_keeps_dashboard_bound_to_its_issuer ... ok
test tests::test_admin_status_authorized ... ok
test tests::test_admin_status_unauthorized ... ok
test tests::test_api_docs ... ok
test tests::test_api_docs_send_a_restrictive_http_csp ... ok
test tests::test_authentication_required ... ok
test tests::test_content_type_handling ... ok
test tests::test_cors_headers ... ok
test tests::test_empty_path_segments ... ok
test tests::test_github_auth_redirect ... ok
test tests::test_health_check_reports_wal_storage_details ... ok
test tests::test_invalid_json_body ... ok
test tests::test_invalid_token ... ok
test tests::test_large_request_body ... ok
test tests::test_lock_name_validation ... ok
test tests::test_method_not_allowed ... ok
test tests::test_metrics_endpoint ... ok
test tests::test_metrics_middleware_basic ... ok
test tests::test_openapi_spec ... ok
test tests::test_path_traversal_protection ... ok
test webhooks::tests::failed_webhook_delete_keeps_runtime_and_durable_state_aligned ... ok
test webhooks::tests::malformed_or_unsupported_persisted_events_fail_closed_on_restart ... ok
test webhooks::tests::webhook_delivery_selection_is_tenant_scoped_and_hides_session_capabilities ... ok
test webhooks::tests::webhook_dns_policy_rejects_private_and_mixed_rebinding_answers ... ok
test webhooks::tests::webhook_event_names_are_validated_before_persistence ... ok
test webhooks::tests::webhook_fanout_live_delivery_never_exceeds_global_bound ... ok
test webhooks::tests::webhook_quota_is_atomic_under_concurrent_creation ... ok
test webhooks::tests::webhook_transport_logs_never_include_url_credentials ... ok
test webhooks::tests::webhook_urls_are_parsed_structurally_and_require_https ... ok

test result: ok. 240 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 23.97s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 58 tests
test acquisition_timeout_caps_headers_body_and_decode_for_both_primitives ... ok
test anchor_fails_closed_when_fixture_teardown_removes_supervisor_state ... ok
test cli_bounds_chunked_success_and_error_response_bodies ... ok
test cli_help_version_and_usage_exit_contract ... ok
test confirmed_stale_lease_exits_lost_without_reacquisition ... ok
test continuous_initial_deadline_contains_detached_groups_after_supervisor_crash ... ok
test continuous_renewal_deadline_survives_clock_rollback_and_supervisor_crash ... ok
test credentialed_cli_never_follows_a_same_authority_tls_downgrade ... ok
test credentialed_cli_redacts_malicious_server_reflection_from_stdout_and_stderr ... ok
test credentialed_loopback_cli_ignores_ambient_proxies ... ok
test detached_guardian_contains_hold_after_whole_supervisor_group_dies_before_authority ... ok
test detached_guardian_survives_whole_supervisor_group_kill_after_worker_start ... ok
test direct_setsid_escape_is_detected_and_contained ... ok
test election_hold_exits_uncertain_after_authority_disappears ... ok
test election_hold_protects_its_leader_capability_transport ... ok
test election_hold_times_out_then_fails_over_with_signal_contract ... ok
test election_release_requires_matching_vacant_term_confirmation ... ok
test guardian_signals_surviving_group_members_after_wrapper_leader_death ... ok
test late_or_mismatched_initial_authority_is_never_emitted ... ok
test local_registration_is_explicit_collision_safe_and_never_reveals_existing_tokens ... ok
test lock_hold_jsonl_distinguishes_held_from_delayed ... ok
test lock_retry_guidance_is_independent_from_session_keepalive ... ok
test long_lock_ttl_cannot_outlive_session_confirmation_deadline ... ok
test main_fallback_contains_groups_when_detached_guardian_dies ... ok
test malicious_zero_server_timings_fail_closed_without_request_storms ... ok
test mismatched_session_keepalive_fails_closed_after_acquisition ... ok
test mismatched_session_keepalive_fails_closed_before_acquisition ... ok
test old_watchdog_contains_replacement_arm_failure_after_supervisor_crash ... ok
test private_ca_https_trust_is_shared_by_cli_and_webhook_clients ... ok
test published_worker_wrapper_exits_when_supervisor_dies_before_readiness ... ok
test queued_watchdog_notification_cannot_strand_stopped_supervisor_groups ... ok
test reference_supervisor_gates_worker_and_cancels_it_on_uncertainty ... ok
test reference_supervisor_gates_worker_before_publishing_handoff ... ok
test reference_supervisor_hup_stops_detached_resistant_groups_and_exits_129 ... ok
test reference_supervisor_keeps_a_watchdog_during_renewal_handoff ... ok
test reference_supervisor_keeps_healthy_long_ttl_elections_through_renewal ... ok
test reference_supervisor_kills_resistant_worker_inside_tight_authority_budget ... ok
test reference_supervisor_kills_term_resistant_worker_group_after_heartbeat_loss ... ok
test reference_supervisor_partial_pre_monitor_pause_preserves_emitted_deadline ... ok
test reference_supervisor_preserves_old_watchdog_during_replacement_arm_failure ... ok
test reference_supervisor_rejects_candidate_and_sequence_mismatches ... ok
test reference_supervisor_rejects_initial_authority_that_expired_in_the_event_pipe ... ok
test reference_supervisor_rejects_missing_future_and_oversized_authority_freshness ... ok
test reference_supervisor_rejects_subsecond_budget_before_worker_start ... ok
test reference_supervisor_reports_authority_after_required_worker_readiness ... ok
test reference_supervisor_revalidates_initial_authority_inside_the_watchdog ... ok
test reference_supervisor_treats_release_as_terminal_and_caps_overrides ... {"schema_version":1,"source":"octostore-supervisor","sequence":1,"event":"leader","kind":"election","name":"room","candidate_id":"agent","term":7}
{"schema_version":1,"source":"octostore-supervisor","sequence":2,"event":"released","kind":"election","name":"room","candidate_id":"agent","term":7}
ok
test renewal_deadline_caps_stalled_headers_and_bodies_for_both_primitives ... ok
test retryable_session_creation_is_retried_before_lock_acquisition ... ok
test same_token_lock_holds_contend_and_fail_over_by_session ... ok
test signal_cleanup_uses_one_two_second_total_budget ... ok
test stale_pgid_identity_never_signals_reused_unrelated_group ... ok
test stopped_guardian_wakes_after_original_kill_deadline_without_new_term_grace ... ok
test substituted_worker_identity_cannot_redirect_guardian_group_signals ... ok
test terminal_containment_keeps_watchdog_until_groups_are_proven_dead ... ok
test watch_is_signal_aware_and_rejects_oversized_unterminated_frames ... ok
test watch_jsonl_envelopes_are_sequenced_and_honor_reconnect_guidance ... ok
test webhook_https_delivery_never_follows_downgrade_or_internal_redirects ... ok

test result: ok. 58 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 177.51s


running 12 tests
test acl_validation_and_session_clamping_are_documented_exactly ... ok
test admin_and_webhook_operations_publish_finite_response_contracts ... ok
test election_mutation_errors_and_unsigned_delays_are_documented_exactly ... ok
test election_watch_uses_one_rate_limit_contract_for_all_admission_bounds ... ok
test local_registration_contract_is_explicit_one_time_and_collision_safe ... ok
test lock_name_contract_preserves_unicode_alphanumeric_components ... ok
test lock_watch_contract_matches_the_initial_snapshot_and_sse_wire_shape ... ok
test oauth_callback_documents_the_implemented_upstream_failure_contract ... ok
test oauth_handoff_is_single_use_and_never_documents_a_bearer_in_location ... ok
test public_holder_identifier_is_explicitly_non_actionable ... ok
test representative_rust_responses_match_openapi_required_fields ... ok
test webhook_event_admission_matches_the_openapi_enum_exactly ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s


running 3 tests
test first_sixty_lines_contain_selection_bootstrap_and_stop_rules ... ok
test skill_has_versioned_contract_and_no_secret_output_anti_patterns ... ok
test source_and_hosted_agent_skills_are_identical_and_bounded ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

Testing acquire_lock
Success

Testing release_lock
Success

Testing acquire_release_cycle
Success

Testing contention_2_threads
Success

Testing contention_10_attempts
Success

Testing many_different_locks/1000
Success

Testing fencing_token_generation/acquire_generates_token
Success

Testing sqlite_persistence
Success

    Updating crates.io index
   Packaging octostore v0.14.0 (/Users/daaronch/code/second-brain/.codex-work/2026-08-10/octostore-unattended-release)
    Updating crates.io index
    Packaged 37 files, 1.2MiB (227.7KiB compressed)
   Verifying octostore v0.14.0 (/Users/daaronch/code/second-brain/.codex-work/2026-08-10/octostore-unattended-release)
   Compiling octostore v0.14.0 (/Users/daaronch/code/second-brain/.codex-work/2026-08-10/octostore-unattended-release/target/package/octostore-0.14.0)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.63s
   Uploading octostore v0.14.0 (/Users/daaronch/code/second-brain/.codex-work/2026-08-10/octostore-unattended-release)
warning: aborting upload due to dry run
package contract passed: strict allowlist, exact archive contents, and warning-free publish dry run
[monitoring-data 0b1e572] probe 2026-08-11T01:05:35Z status=ok
 1 file changed, 1 insertion(+)
stable release tag fixture passed: rc, preview, nightly, malformed, and build-suffixed tags rejected
EVIDENCE provenance_rejected case=tag-commit-mismatch before_mutation=true
EVIDENCE provenance_rejected case=off-main-tag before_mutation=true
EVIDENCE provenance_rejected case=asset-digest before_mutation=true
EVIDENCE provenance_rejected case=previous-asset-digest before_mutation=true
EVIDENCE proof_failure case=health rollback=verified
EVIDENCE proof_failure case=installer rollback=verified
EVIDENCE proof_failure case=supervisor-provenance rollback=verified
EVIDENCE proof_failure case=supervised-canary rollback=verified
EVIDENCE proof_failure case=rollback-health rollback_failure=reported
EVIDENCE public_proof health=validated installer_commit=2d1587984197e1123b25f5eae930cf19e1587ee1 installer_version=0.14.0
deployment failure fixture passed: pre-mutation provenance rejection, ERR/INT/TERM/HUP rollback, health/installer proof failures, rerun recovery, and 6 exact site files
crates.io resume fixture passed: absent, exact, mismatched, and yanked versions
release contract passed: trusted default-branch dispatch, reviewer-gated publication, split policy/migration authority, transactional crates.io and SSH-secret migration, immutable publication cleanup, durable deployment inputs, contained metrics writes, locked tools, behavioral provenance, rollback, package resume, and public proof
downgrade compatibility smoke passed: v0.14 impossible sentinel -> v0.13.2 admin rejection/hold/acquire -> v0.14 successor recovery

added 35 packages in 483ms

> lint:openapi
> redocly lint openapi.yaml


> lint:html
> html-validate site/index.html site/agents/index.html site/docs/index.html site/leader-election/index.html site/coordination/index.html site/dashboard.html site/status.html && html-validate --rule=no-inline-style:off site/admin.html


> test:site:static
> node scripts/check-site.mjs && node scripts/check-site-behavior.mjs

site contract passed: 13 HTML files, routes/assets, accessibility structure, pinned onboarding, compatibility claim boundaries, CSP-pinned credential surfaces and rotation, capability-free lock lists, strict RFC3339 live demo schemas, and social card
site behavior passed: strict RFC3339 create/status/SSE and lock schemas, observer invalidation, bounded unconfirmed state, selectable dual instructions, one-time auth exchange, durable validated token rotation, legacy URL rejection, capability-free lock rendering, and status-aware validated admin metrics

> test:site:browser
> env -u NO_COLOR playwright test


Running 8 tests using 1 worker

[1/8] tests/browser/site.spec.mjs:51:5 › home passes desktop first-viewport and accessibility checks
[2/8] tests/browser/site.spec.mjs:51:5 › home passes narrow first-viewport and accessibility checks
[3/8] tests/browser/site.spec.mjs:51:5 › agents passes desktop first-viewport and accessibility checks
[4/8] tests/browser/site.spec.mjs:51:5 › agents passes narrow first-viewport and accessibility checks
[5/8] tests/browser/site.spec.mjs:86:1 › homepage creates one shared room and produces two copyable instructions
[6/8] tests/browser/site.spec.mjs:133:1 › agents page copy control works from the keyboard
[7/8] tests/browser/site.spec.mjs:161:1 › public protected-work examples keep the worker behind the supervisor
[8/8] tests/browser/site.spec.mjs:231:1 › reduced-motion preference disables first-viewport animation
  8 passed (11.0s)

│
●   codex  Agent detected — installing non-interactively
[?25l│
◇  Source: /Users/daaronch/code/second-brain/.codex-work/2026-08-10/octostore-unattended-release
[?25h[?25l│
◇  Local path validated
[?25h[?25l│
◇  Found 1 skill
[?25h│
●  Selected 1 skill: octostore

│
◇  Installation Summary ───────────────────────────────────────────────────────╮
│                                                                              │
│  ~/code/second-brain/.codex-work/2026-08-10/octostore-unattended-release/.s  │
│  moke-skill-install.xqXgKi/.agents/skills/octostore                          │
│    copy → Codex                                                              │
│                                                                              │
├──────────────────────────────────────────────────────────────────────────────╯
[?25l│
◇  Installation complete
[?25h
│
◇  Installed 1 skill ──────────────────────────────────────────────────────────╮
│                                                                              │
│  ✓ octostore (copied)                                                        │
│    → ~/code/second-brain/.codex-work/2026-08-10/octostore-unattended-releas  │
│  e/.smoke-skill-install.xqXgKi/.agents/skills/octostore                      │
│                                                                              │
├──────────────────────────────────────────────────────────────────────────────╯

│
└  Done!  Review skills before use; they run with full agent permissions.

skill install smoke passed: pinned skills CLI installed octostore unattended
shared room: 3qJ1lyv_FYpLVILQtlUota-6Z5G5VpmF
agent-atlas leads; agent-comet waits
agent-comet took over after cancellation
no remaining supervisor processes
two-agent supervised demo passed: waiting, takeover, and cancellation
two-agent smoke passed: public supervised demo ran verbatim
supervisor smoke passed: worker gated on authority and stopped on uncertainty
release fixture smoke passed: immutable metadata rejected substituted payload/checksums; transactional installed pair ran server, two-agent, and supervisor paths.