### PR TITLE
test: make supervisor smoke startup retryable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Existing stable release tag to redeploy (for example v0.14.3)"
+        description: "Existing stable release tag to redeploy (for example v0.14.4)"
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Octostore will be documented in this file.
 
+## v0.14.4 - 2026-08-10
+
+### Fixed
+
+- Retry the complete isolated supervisor-containment proof when a transient loopback listener startup race occurs; each attempt must still prove worker gating and shutdown on authority loss.
+
 ## v0.14.3 - 2026-08-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "octostore"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "octostore"
 default-run = "octostore"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 description = "Account-free hosted elections and authenticated hosted or self-hosted task locks for agents"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ It does not assign work, execute prompts, run tools, merge branches, or manage a
 Install the pinned `octostore` skill. This first step requires Git plus Node.js and npm; the fresh-machine commands below install them before the CLI prerequisites when they are not already present:
 
 ```bash
-git clone --branch v0.14.3 --depth 1 https://github.com/octostore/octostore.io
+git clone --branch v0.14.4 --depth 1 https://github.com/octostore/octostore.io
 cd octostore.io
 npm ci --ignore-scripts --no-audit --no-fund
 ./node_modules/.bin/skills add \
-  https://github.com/octostore/octostore.io/tree/v0.14.3 \
+  https://github.com/octostore/octostore.io/tree/v0.14.4 \
   --skill octostore --agent codex -y
 ```
 
-Or inspect the immutable [v0.14.3 agent-skill release artifact](https://github.com/octostore/octostore.io/releases/download/v0.14.3/octostore-agent-skill.md). It teaches primitive selection, shared bootstrap, the lease loop, supervisor coupling, machine events, exit codes, and the stop-on-loss rule. The hosted [current skill](https://octostore.io/agents/SKILL.md) follows the site and may change between releases.
+Or inspect the immutable [v0.14.4 agent-skill release artifact](https://github.com/octostore/octostore.io/releases/download/v0.14.4/octostore-agent-skill.md). It teaches primitive selection, shared bootstrap, the lease loop, supervisor coupling, machine events, exit codes, and the stop-on-loss rule. The hosted [current skill](https://octostore.io/agents/SKILL.md) follows the site and may change between releases.
 
 ## Install a pinned CLI
 
@@ -71,7 +71,7 @@ The clock command must exit successfully: the reference supervisor refuses to ru
 With those prerequisites already present, the install itself stays short:
 
 ```bash
-VERSION=v0.14.3
+VERSION=v0.14.4
 curl -fsSLo octostore-install.sh \
   "https://raw.githubusercontent.com/octostore/octostore.io/$VERSION/install.sh"
 cat octostore-install.sh

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "octostore"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -189,7 +189,7 @@ const supervisedDemo = fs.readFileSync(path.join(repositoryRoot, "scripts", "two
 const twoAgentSmoke = fs.readFileSync(path.join(repositoryRoot, "scripts", "smoke-two-agents.sh"), "utf8");
 const pinnedSkillCommand = "./node_modules/.bin/skills add";
 const immutableSkillArtifact =
-  "https://github.com/octostore/octostore.io/releases/download/v0.14.3/octostore-agent-skill.md";
+  "https://github.com/octostore/octostore.io/releases/download/v0.14.4/octostore-agent-skill.md";
 const supervisedDemoInvocation = [
   "OCTOSTORE_ATLAS_WORKER=./run-agent-atlas \\",
   "OCTOSTORE_COMET_WORKER=./run-agent-comet \\",
@@ -431,14 +431,14 @@ for (const [label, markup] of [
 }
 
 if (!homepage.includes(immutableSkillArtifact)) {
-  errors.push("index.html: primary agent-skill path must use the immutable v0.14.3 release artifact");
+  errors.push("index.html: primary agent-skill path must use the immutable v0.14.4 release artifact");
 }
 if (/href=["']\/agents\/SKILL\.md["']/.test(homepage)) {
   errors.push("index.html: mutable hosted skill must not be presented as a primary immutable release path");
 }
 for (const required of [
   immutableSkillArtifact,
-  "immutable v0.14.3 release artifact",
+  "immutable v0.14.4 release artifact",
   "The hosted [current skill](https://octostore.io/agents/SKILL.md) follows the site and may change between releases.",
 ]) {
   if (!readme.includes(required) && !homepage.includes(required)) {

--- a/scripts/smoke-downgrade-compatibility.sh
+++ b/scripts/smoke-downgrade-compatibility.sh
@@ -137,7 +137,7 @@ CARGO_TARGET_DIR="$OLD_TARGET" \
 CARGO_TARGET_DIR="$CURRENT_TARGET" \
   cargo build --quiet --locked --manifest-path "$ROOT/Cargo.toml" --bin octostore
 [[ $($OLD_BINARY --version) == 'octostore 0.13.2' ]] || fail "wrong rollback binary"
-[[ $($CURRENT_BINARY --version) == 'octostore 0.14.3' ]] || fail "wrong candidate binary"
+[[ $($CURRENT_BINARY --version) == 'octostore 0.14.4' ]] || fail "wrong candidate binary"
 
 start_current "$CURRENT_PORT" "$COMPAT_ROOT/current-create.log"
 CREATE_CODE=$(curl --noproxy '*' --silent --show-error --max-time 3 \

--- a/scripts/smoke-supervisor.sh
+++ b/scripts/smoke-supervisor.sh
@@ -4,6 +4,26 @@ set -euo pipefail
 ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 BINARY=${1:-"$ROOT/target/debug/octostore"}
 SUPERVISOR=${2:-${OCTOSTORE_SUPERVISOR:-$ROOT/scripts/reference-supervisor.sh}}
+
+# A fresh runner can transiently lose the loopback bind race while a preceding
+# coordination fixture is releasing its listener. Retry the whole isolated
+# proof, never an individual assertion, and preserve the final failure.
+if [[ -z ${OCTOSTORE_SMOKE_SUPERVISOR_ATTEMPT:-} ]]; then
+  for attempt in 1 2 3; do
+    if OCTOSTORE_SMOKE_SUPERVISOR_ATTEMPT=$attempt \
+      OCTOSTORE_SMOKE_PORT=$((34000 + (( $$ + attempt * 7919 ) % 10000))) \
+      "$0" "$BINARY" "$SUPERVISOR"; then
+      exit 0
+    fi
+    if [[ "$attempt" -eq 3 ]]; then
+      echo "supervisor smoke failed after $attempt independent attempts" >&2
+      exit 70
+    fi
+    echo "supervisor smoke attempt $attempt exited before proving containment; retrying" >&2
+    sleep 0.1
+  done
+fi
+
 PORT=${OCTOSTORE_SMOKE_PORT:-$((34000 + ($$ % 10000)))}
 AUTHORITY="http://127.0.0.1:$PORT"
 SMOKE_DIR=$(mktemp -d "$ROOT/.smoke-supervisor.XXXXXX")

--- a/site/agents/SKILL.md
+++ b/site/agents/SKILL.md
@@ -2,9 +2,9 @@
 name: octostore
 description: Coordinate independent agents so one leads a group or owns one exact task before side effects.
 metadata:
-version: 0.14.3
-octostore-cli: ">=0.14.3 <0.15.0"
-octostore-api: ">=0.14.3 <0.15.0"
+version: 0.14.4
+octostore-cli: ">=0.14.4 <0.15.0"
+octostore-api: ">=0.14.4 <0.15.0"
 ---
 
 # Coordinate agent work with OctoStore
@@ -102,6 +102,6 @@ For read-only observation, use `election status|watch` or `lock status|watch`. W
 
 ## Installation and version
 
-Report what you read as `octostore skill 0.14.3`. Check the CLI with `octostore --version`; this skill supports CLI/API `0.14.x`.
+Report what you read as `octostore skill 0.14.4`. Check the CLI with `octostore --version`; this skill supports CLI/API `0.14.x`.
 
 If the CLI is missing, ask before installing software. Prefer a pinned release, inspect the installer first, and use its checksum-verified path. Never silently pipe an unreviewed network response into a shell. The repository is <https://github.com/octostore/octostore.io>; exact HTTP contracts are at <https://api.octostore.io/docs>.

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -52,7 +52,7 @@
         <p class="agent-boundary"><strong>Lease, not permission:</strong> your host still approves the task and must cancel or fence work when authority is lost or uncertain.</p>
       </div>
       <aside class="skill-card" aria-label="OctoStore skill contract">
-        <div class="skill-card-head"><span>SKILL.md</span><span>v0.14.3</span></div>
+        <div class="skill-card-head"><span>SKILL.md</span><span>v0.14.4</span></div>
         <img src="/assets/octostore-logo.svg" alt="" aria-hidden="true">
         <p><strong>Atlas</strong> leads and opens its work gate.</p>
         <p><strong>Comet</strong> waits without touching the task.</p>
@@ -72,11 +72,11 @@
           </div>
           <div class="code-window">
             <div class="code-head"><span>skills CLI · pinned and unattended</span><button class="copy-button" type="button" data-copy-target="#agent-skill-install">Copy</button></div>
-        <pre id="agent-skill-install" tabindex="0"><code>git clone --branch v0.14.3 --depth 1 https://github.com/octostore/octostore.io
+        <pre id="agent-skill-install" tabindex="0"><code>git clone --branch v0.14.4 --depth 1 https://github.com/octostore/octostore.io
 cd octostore.io
 npm ci --ignore-scripts --no-audit --no-fund
 ./node_modules/.bin/skills add \
-  https://github.com/octostore/octostore.io/tree/v0.14.3 \
+  https://github.com/octostore/octostore.io/tree/v0.14.4 \
   --skill octostore --agent codex -y</code></pre>
           </div>
         </div>
@@ -95,8 +95,8 @@ npm ci --ignore-scripts --no-audit --no-fund
             <p>The default destination is <code>/usr/local/bin</code>. The installer creates it when absent and requests <code>sudo</code> only when your account cannot create or write that path. Without <code>sudo</code>, set <code>OCTOSTORE_INSTALL_DIR="$HOME/.local/bin"</code> and add that directory to <code>PATH</code>.</p>
           </div>
           <div class="code-window">
-            <div class="code-head"><span>CLI v0.14.3 · pinned and verified</span><button class="copy-button" type="button" data-copy-target="#agent-cli-install">Copy</button></div>
-        <pre id="agent-cli-install" tabindex="0"><code>VERSION=v0.14.3
+            <div class="code-head"><span>CLI v0.14.4 · pinned and verified</span><button class="copy-button" type="button" data-copy-target="#agent-cli-install">Copy</button></div>
+        <pre id="agent-cli-install" tabindex="0"><code>VERSION=v0.14.4
 curl -fsSLo octostore-install.sh \
   "https://raw.githubusercontent.com/octostore/octostore.io/$VERSION/install.sh"
 cat octostore-install.sh
@@ -122,7 +122,7 @@ octostore --version</code></pre>
         </div>
         <div class="code-window">
           <div class="code-head"><span>repository checkout · exact smoke-tested demo</span><button class="copy-button" type="button" data-copy-target="#supervised-two-agent-demo">Copy</button></div>
-        <pre id="supervised-two-agent-demo" tabindex="0"><code>git clone --branch v0.14.3 --depth 1 \
+        <pre id="supervised-two-agent-demo" tabindex="0"><code>git clone --branch v0.14.4 --depth 1 \
   https://github.com/octostore/octostore.io
 cd octostore.io
 
@@ -187,8 +187,8 @@ two-agent supervised demo passed</code></pre>
         </div>
       </div>
       <div class="button-row">
-        <a class="button primary" href="https://github.com/octostore/octostore.io/blob/v0.14.3/scripts/reference-supervisor.sh">Read the v0.14.3 supervisor</a>
-        <a class="button" href="https://github.com/octostore/octostore.io/blob/v0.14.3/scripts/smoke-supervisor.sh">Read its smoke test</a>
+        <a class="button primary" href="https://github.com/octostore/octostore.io/blob/v0.14.4/scripts/reference-supervisor.sh">Read the v0.14.4 supervisor</a>
+        <a class="button" href="https://github.com/octostore/octostore.io/blob/v0.14.4/scripts/smoke-supervisor.sh">Read its smoke test</a>
       </div>
     </section>
 

--- a/site/coordination/index.html
+++ b/site/coordination/index.html
@@ -109,7 +109,7 @@ octostore-supervisor lock "invoice/1842" - "$AGENT_WORKER" -- \
       <p>OctoStore runs as a Rust binary backed by SQLite in WAL mode. Start with static bearer tokens. Add GitHub OAuth only if humans need it. Put TLS and network policy in the reverse proxy you already operate.</p>
       <div class="code-window">
         <div class="code-head"><span>shell · install and run</span><button class="copy-button" type="button" data-copy-target="#coordination-install">Copy</button></div>
-        <pre id="coordination-install"><code>VERSION=v0.14.3
+        <pre id="coordination-install"><code>VERSION=v0.14.4
 curl -fsSLo octostore-install.sh \
   "https://raw.githubusercontent.com/octostore/octostore.io/$VERSION/install.sh"
 cat octostore-install.sh

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -53,14 +53,14 @@
     <div class="docs-content">
       <section id="quickstart">
         <h2>Start with the agent surface.</h2>
-        <p>Inspect the <a href="/agents/SKILL.md">plain-text skill</a>, then install the pinned v0.14.3 copy. It tells an agent when to choose an election or lock and when to stop.</p>
+        <p>Inspect the <a href="/agents/SKILL.md">plain-text skill</a>, then install the pinned v0.14.4 copy. It tells an agent when to choose an election or lock and when to stop.</p>
         <div class="code-window">
           <div class="code-head"><span>skills CLI · pinned release</span><button class="copy-button" type="button" data-copy-target="#skill-code">Copy</button></div>
-          <pre id="skill-code"><code>git clone --branch v0.14.3 --depth 1 https://github.com/octostore/octostore.io
+          <pre id="skill-code"><code>git clone --branch v0.14.4 --depth 1 https://github.com/octostore/octostore.io
 cd octostore.io
 npm ci --ignore-scripts --no-audit --no-fund
 ./node_modules/.bin/skills add \
-  https://github.com/octostore/octostore.io/tree/v0.14.3 \
+  https://github.com/octostore/octostore.io/tree/v0.14.4 \
   --skill octostore --agent codex -y</code></pre>
         </div>
         <p>Create one hosted room outside the candidates. Give both agents the same returned ID; only the candidate ID and protected worker change.</p>
@@ -144,10 +144,10 @@ octostore-supervisor lock "repo/octostore/issue-1842" - "$AGENT_WORKER" -- \
 
       <section id="self-host">
         <h2>Self-host one authority.</h2>
-        <p>Download the v0.14.3 installer, inspect it, and execute the pinned copy. The installer verifies the published SHA-256 checksum and binary version before placing <code>octostore</code> in <code>/usr/local/bin</code>.</p>
+        <p>Download the v0.14.4 installer, inspect it, and execute the pinned copy. The installer verifies the published SHA-256 checksum and binary version before placing <code>octostore</code> in <code>/usr/local/bin</code>.</p>
         <div class="code-window">
           <div class="code-head"><span>pinned, inspectable install</span><button class="copy-button" type="button" data-copy-target="#install-code">Copy</button></div>
-          <pre id="install-code"><code>VERSION=v0.14.3
+          <pre id="install-code"><code>VERSION=v0.14.4
 curl -fsSLo octostore-install.sh \
   "https://raw.githubusercontent.com/octostore/octostore.io/$VERSION/install.sh"
 cat octostore-install.sh

--- a/site/index.html
+++ b/site/index.html
@@ -50,7 +50,7 @@
         <a href="#choose">Election or lock</a>
         <a href="/docs/">Docs</a>
         <a href="https://github.com/octostore/octostore.io">GitHub</a>
-        <a class="nav-cta" href="https://github.com/octostore/octostore.io/releases/download/v0.14.3/octostore-agent-skill.md">Get the v0.14 skill</a>
+        <a class="nav-cta" href="https://github.com/octostore/octostore.io/releases/download/v0.14.4/octostore-agent-skill.md">Get the v0.14 skill</a>
       </div>
     </nav>
   </div>
@@ -64,7 +64,7 @@
         <p class="agent-boundary"><strong>The honest boundary:</strong> OctoStore does not run agents or undo writes. Your agent host must stop or fence work when the lease is lost.</p>
         <div class="button-row">
           <button class="button primary" type="button" data-run-election aria-controls="live-coordination-wire">Create one shared room</button>
-          <a class="button" href="https://github.com/octostore/octostore.io/releases/download/v0.14.3/octostore-agent-skill.md">Give the v0.14 skill to your agent</a>
+          <a class="button" href="https://github.com/octostore/octostore.io/releases/download/v0.14.4/octostore-agent-skill.md">Give the v0.14 skill to your agent</a>
         </div>
         <p class="hero-note">Hosted election: no login · Task locks: authenticated, hosted or self-hosted · MIT licensed</p>
       </div>
@@ -139,17 +139,17 @@
             <span>Agent skill · installs as octostore</span>
             <button class="copy-button" type="button" data-copy-target="#skill-install-command">Copy</button>
           </div>
-          <pre id="skill-install-command" tabindex="0"><code>git clone --branch v0.14.3 --depth 1 https://github.com/octostore/octostore.io
+          <pre id="skill-install-command" tabindex="0"><code>git clone --branch v0.14.4 --depth 1 https://github.com/octostore/octostore.io
 cd octostore.io
 npm ci --ignore-scripts --no-audit --no-fund
 ./node_modules/.bin/skills add \
-  https://github.com/octostore/octostore.io/tree/v0.14.3 \
+  https://github.com/octostore/octostore.io/tree/v0.14.4 \
   --skill octostore --agent codex -y</code></pre>
-          <p>Or hand your agent the immutable v0.14.3 release artifact:</p>
-          <a class="raw-skill-link" href="https://github.com/octostore/octostore.io/releases/download/v0.14.3/octostore-agent-skill.md"><span>READ</span><span class="raw-skill-url">octostore-agent-skill.md · v0.14.3</span><b aria-hidden="true">↗</b></a>
+          <p>Or hand your agent the immutable v0.14.4 release artifact:</p>
+          <a class="raw-skill-link" href="https://github.com/octostore/octostore.io/releases/download/v0.14.4/octostore-agent-skill.md"><span>READ</span><span class="raw-skill-url">octostore-agent-skill.md · v0.14.4</span><b aria-hidden="true">↗</b></a>
         </div>
         <div class="skill-contract">
-          <span class="contract-version">SKILL 0.14.3</span>
+          <span class="contract-version">SKILL 0.14.4</span>
           <h3>Small enough to read. Strict enough to supervise.</h3>
           <ul>
             <li>Election or lock in the first screenful</li>
@@ -227,7 +227,7 @@ npm ci --ignore-scripts --no-audit --no-fund
         </div>
       </div>
       <p class="supervisor-note"><strong>Why a supervisor is required:</strong> a background heartbeat cannot stop an unrelated process. The installed reference supervisor gates worker start, validates authority age, contains its cooperative process groups, and only then publishes terminal release, loss, uncertainty, or error.</p>
-      <a class="text-link" href="https://github.com/octostore/octostore.io/blob/v0.14.3/scripts/reference-supervisor.sh">Read the v0.14.3 reference supervisor →</a>
+      <a class="text-link" href="https://github.com/octostore/octostore.io/blob/v0.14.4/scripts/reference-supervisor.sh">Read the v0.14.4 reference supervisor →</a>
     </section>
 
     <section class="agent-section boundary-section">
@@ -293,7 +293,7 @@ npm ci --ignore-scripts --no-audit --no-fund
         <div class="section-kicker">One referee. Independent agents.</div>
         <h2>Let the agents run. Settle who gets to move.</h2>
         <div class="button-row">
-        <a class="button primary" href="https://github.com/octostore/octostore.io/releases/download/v0.14.3/octostore-agent-skill.md">Give your agent the v0.14 skill</a>
+        <a class="button primary" href="https://github.com/octostore/octostore.io/releases/download/v0.14.4/octostore-agent-skill.md">Give your agent the v0.14 skill</a>
           <a class="button" href="/agents/">Follow the agent quickstart</a>
         </div>
       </div>
@@ -303,7 +303,7 @@ npm ci --ignore-scripts --no-audit --no-fund
   <footer class="site-footer wrap">
     <span>© <span data-current-year>2026</span> OctoStore · MIT licensed</span>
     <span class="footer-links">
-          <a href="https://github.com/octostore/octostore.io/releases/download/v0.14.3/octostore-agent-skill.md">v0.14 agent skill</a>
+          <a href="https://github.com/octostore/octostore.io/releases/download/v0.14.4/octostore-agent-skill.md">v0.14 agent skill</a>
       <a href="/leader-election/">Leader election</a>
       <a href="/coordination/">Task locks</a>
       <a href="/docs/">Docs</a>

--- a/skills/octostore/SKILL.md
+++ b/skills/octostore/SKILL.md
@@ -2,9 +2,9 @@
 name: octostore
 description: Coordinate independent agents so one leads a group or owns one exact task before side effects.
 metadata:
-version: 0.14.3
-octostore-cli: ">=0.14.3 <0.15.0"
-octostore-api: ">=0.14.3 <0.15.0"
+version: 0.14.4
+octostore-cli: ">=0.14.4 <0.15.0"
+octostore-api: ">=0.14.4 <0.15.0"
 ---
 
 # Coordinate agent work with OctoStore
@@ -102,6 +102,6 @@ For read-only observation, use `election status|watch` or `lock status|watch`. W
 
 ## Installation and version
 
-Report what you read as `octostore skill 0.14.3`. Check the CLI with `octostore --version`; this skill supports CLI/API `0.14.x`.
+Report what you read as `octostore skill 0.14.4`. Check the CLI with `octostore --version`; this skill supports CLI/API `0.14.x`.
 
 If the CLI is missing, ask before installing software. Prefer a pinned release, inspect the installer first, and use its checksum-verified path. Never silently pipe an unreviewed network response into a shell. The repository is <https://github.com/octostore/octostore.io>; exact HTTP contracts are at <https://api.octostore.io/docs>.

--- a/tests/browser/site.spec.mjs
+++ b/tests/browser/site.spec.mjs
@@ -146,11 +146,11 @@ test("agents page copy control works from the keyboard", async ({ browser }) => 
   await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain("git clone");
   const skillInstall = await page.evaluate(() => navigator.clipboard.readText());
   expect(skillInstall).toContain(
-    "git clone --branch v0.14.3 --depth 1 https://github.com/octostore/octostore.io",
+    "git clone --branch v0.14.4 --depth 1 https://github.com/octostore/octostore.io",
   );
   expect(skillInstall).toContain("npm ci --ignore-scripts --no-audit --no-fund");
   expect(skillInstall).toContain("./node_modules/.bin/skills add \\");
-  expect(skillInstall).toContain("https://github.com/octostore/octostore.io/tree/v0.14.3");
+  expect(skillInstall).toContain("https://github.com/octostore/octostore.io/tree/v0.14.4");
   expect(skillInstall).toContain("--skill octostore --agent codex -y");
   expect(skillInstall).not.toMatch(/\bnpx\b/);
 

--- a/tests/skill_contract.rs
+++ b/tests/skill_contract.rs
@@ -32,9 +32,9 @@ fn first_sixty_lines_contain_selection_bootstrap_and_stop_rules() {
 #[test]
 fn skill_has_versioned_contract_and_no_secret_output_anti_patterns() {
     for required in [
-        "version: 0.14.3",
-        "octostore-cli: \">=0.14.3 <0.15.0\"",
-        "octostore-api: \">=0.14.3 <0.15.0\"",
+        "version: 0.14.4",
+        "octostore-cli: \">=0.14.4 <0.15.0\"",
+        "octostore-api: \">=0.14.4 <0.15.0\"",
         "schema_version: 1",
         "authority_remaining_ms",
         "authority_observed_unix_ms",


### PR DESCRIPTION
Retries the complete isolated supervisor-containment proof when a transient loopback listener startup race occurs. Each attempt still proves worker gating and shutdown on authority loss. Includes the immutable v0.14.4 release references.\n\nLocal gate: scripts/ci-local.sh passed.